### PR TITLE
feat(cmd): new 'info' command to check compatibility

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ https://i3wm.org/docs/userguide.html#_scratchpad
 	rootCmd.AddCommand(ShowCmd(aerospaceClient))
 	rootCmd.AddCommand(SummonCmd(aerospaceClient))
 	rootCmd.AddCommand(NextCmd(aerospaceClient))
+	rootCmd.AddCommand(InfoCmd(aerospaceClient))
 
 	return rootCmd
 }


### PR DESCRIPTION
New command to check compatibility with current aerospace installed

```bash
aerospace-scratchpad info

// Output
Aerospace Scratchpad

[Aerospace]
Version: 0.15.2-Beta b6cf82771f245ab7349a93baf8709e171537ff58
Socket: /tmp/bobko.aerospace-user.sock

[Aerospace scratchpad]
Workspace: .scratchpad

[Compatibility]
Status: Compatible.

```