### PR TITLE
fix(cmd): handle multiple windows

### DIFF
--- a/cmd/__snapshots__/show_test.snap
+++ b/cmd/__snapshots__/show_test.snap
@@ -80,7 +80,7 @@ Error
 aerospace-scratchpad show Finder
 
 Output
-Window '5678 | Finder ' is showed
+Window '5678 | Finder ' is focused
 
 Error
 <nil>
@@ -168,6 +168,62 @@ aerospace-scratchpad show
 
 Output
 Error: <pattern> cannot be empty
+
+Error
+<nil>
+---
+
+[TestShowCmd/MultipleWindows/brings_all_windows_to_focused_workspace - 1]
+[]testutils.AeroSpaceTree{
+    {
+        Windows: {
+            {WindowID:5678, WindowTitle:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:5679, WindowTitle:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws1"},
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
+        FocusedWindowId: 0,
+    },
+    {
+        Windows: {
+            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws2"},
+        FocusedWindowId: 91011,
+    },
+}
+aerospace-scratchpad show Finder
+
+Output
+Window '5678 | Finder1  | ws1' is summoned
+Window '5679 | Finder2  | ws1' is summoned
+
+Error
+<nil>
+---
+
+[TestShowCmd/MultipleWindows/sends_all_windows_to_scratchpad_if_at_least_one_window_is_focused - 1]
+[]testutils.AeroSpaceTree{
+    {
+        Windows: {
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
+        FocusedWindowId: 0,
+    },
+    {
+        Windows: {
+            {WindowID:5678, WindowTitle:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:5679, WindowTitle:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws2"},
+        FocusedWindowId: 5678,
+    },
+}
+aerospace-scratchpad show Finder
+
+Output
+Window '5678 | Finder1  | ws2' is focused
+Window '5679 | Finder2  | ws2' is focused
 
 Error
 <nil>

--- a/cmd/__snapshots__/show_test.snap
+++ b/cmd/__snapshots__/show_test.snap
@@ -228,3 +228,32 @@ Window '5679 | Finder2  | ws2' is focused
 Error
 <nil>
 ---
+
+[TestShowCmd/MultipleWindows/gives_priority_to_bringing_scratchpads_together - 1]
+[]testutils.AeroSpaceTree{
+    {
+        Windows: {
+            {WindowID:5678, WindowTitle:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:22, WindowTitle:"", AppName:"Browser", AppBundleID:"", Workspace:"ws1"},
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
+        FocusedWindowId: 0,
+    },
+    {
+        Windows: {
+            {WindowID:5679, WindowTitle:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws2"},
+        FocusedWindowId: 91011,
+    },
+}
+aerospace-scratchpad show Finder
+
+Output
+Window '5678 | Finder1  | ws1' is summoned
+Window '5679 | Finder2  | ws2' is focused
+
+Error
+<nil>
+---

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -82,7 +82,11 @@ If no pattern is provided, it moves the currently focused window.
 					"floating",
 				)
 				if err != nil {
-					return fmt.Errorf("unable to set layout for window '%+v'\n%v", window, err)
+					fmt.Printf(
+						"warn: unable to set layout for window '%+v' to floating\n%s",
+						window,
+						err,
+					)
 				}
 
 				movedCount++

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -112,6 +112,20 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 			// NOTE: To avoid the ping pong of windows, so priority is
 			// for bringing windows to the focused workspace
 			if len(windowsOutsideView) > 0 {
+				// Make sure to bring the remaining matched windows to the front
+				for _, window := range windowsInFocusedWorkspace {
+					err = aerospaceClient.SetFocusByWindowID(window.WindowID)
+					if err != nil {
+						stderr.Printf(
+							"Error: unable to set focus to window '%+v'\n%s",
+							window,
+							err,
+						)
+						return
+					}
+					fmt.Printf("Window '%+v' is focused\n", window)
+				}
+
 				return
 			}
 

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -517,5 +517,110 @@ func TestShowCmd(t *testing.T) {
 			expectedError := fmt.Sprintf("Error\n%+v", err)
 			snaps.MatchSnapshot(t, tree, cmdAsString, "Output", out, expectedError)
 		})
+
+		tt.Run("gives priority to bringing scratchpads together", func(t *testing.T) {
+			command := "show"
+			args := []string{command, "Finder"}
+
+			ctrl := gomock.NewController(tt)
+			defer ctrl.Finish()
+
+			tree := []testutils.AeroSpaceTree{
+				{
+					Windows: []aerospacecli.Window{
+						{
+							AppName:   "Finder1",
+							WindowID:  5678,
+							Workspace: "ws1",
+						},
+						{
+							AppName:   "Browser",
+							WindowID:  22,
+							Workspace: "ws1",
+						},
+					},
+					Workspace: &aerospacecli.Workspace{
+						Workspace: "ws1",
+					},
+					FocusedWindowId: 0, // Not focused
+				},
+				{
+					Windows: []aerospacecli.Window{
+						{
+							AppName:   "Finder2",
+							WindowID:  5679,
+							Workspace: "ws2",
+						},
+						{
+							AppName:   "Terminal",
+							WindowID:  91011,
+							Workspace: "ws2",
+						},
+					},
+					Workspace: &aerospacecli.Workspace{
+						Workspace: "ws2",
+					},
+					FocusedWindowId: 91011,
+				},
+			}
+
+			allWindows := testutils.ExtractAllWindows(tree)
+			focusedTree := testutils.ExtractFocusedTree(tree)
+			focusedWindow := testutils.ExtractFocusedWindow(tree)
+
+			aerospaceClient := mock_aerospace.NewMockAeroSpaceClient(ctrl)
+			gomock.InOrder(
+				aerospaceClient.EXPECT().
+					GetAllWindows().
+					Return(allWindows, nil).
+					Times(1),
+
+				aerospaceClient.EXPECT().
+					GetFocusedWorkspace().
+					Return(focusedTree.Workspace, nil).
+					Times(1),
+
+				aerospaceClient.EXPECT().
+					GetFocusedWindow().
+					Return(focusedWindow, nil).
+					Times(1),
+
+				aerospaceClient.EXPECT().
+					MoveWindowToWorkspace(
+						tree[0].Windows[0].WindowID,
+						focusedTree.Workspace.Workspace,
+					).
+					Return(nil).
+					Times(1),
+
+				aerospaceClient.EXPECT().
+					SetFocusByWindowID(
+						tree[0].Windows[0].WindowID,
+					).
+					Return(nil).
+					Times(1),
+
+				aerospaceClient.EXPECT().
+					SetFocusByWindowID(
+						tree[1].Windows[0].WindowID,
+					).
+					Return(nil).
+					Times(1),
+			)
+
+			cmd := RootCmd(aerospaceClient)
+			out, err := testutils.CmdExecute(cmd, args...)
+			if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+
+			if out == "" {
+				t.Errorf("Expected output, got empty string")
+			}
+
+			cmdAsString := "aerospace-scratchpad " + strings.Join(args, " ") + "\n"
+			expectedError := fmt.Sprintf("Error\n%+v", err)
+			snaps.MatchSnapshot(t, tree, cmdAsString, "Output", out, expectedError)
+		})
 	})
 }

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -322,4 +322,200 @@ func TestShowCmd(t *testing.T) {
 		expectedError := fmt.Sprintf("Error\n%+v", err)
 		snaps.MatchSnapshot(t, tree, cmdAsString, "Output", out, expectedError)
 	})
+
+	t.Run("MultipleWindows", func(tt *testing.T) {
+		tt.Run("brings all windows to focused workspace", func(t *testing.T) {
+			command := "show"
+			args := []string{command, "Finder"}
+
+			ctrl := gomock.NewController(tt)
+			defer ctrl.Finish()
+
+			tree := []testutils.AeroSpaceTree{
+				{
+					Windows: []aerospacecli.Window{
+						{
+							AppName:   "Finder1",
+							WindowID:  5678,
+							Workspace: "ws1",
+						},
+						{
+							AppName:   "Finder2",
+							WindowID:  5679,
+							Workspace: "ws1",
+						},
+					},
+					Workspace: &aerospacecli.Workspace{
+						Workspace: "ws1",
+					},
+					FocusedWindowId: 0, // Not focused
+				},
+				{
+					Windows: []aerospacecli.Window{
+						{
+							AppName:   "Terminal",
+							WindowID:  91011,
+							Workspace: "ws2",
+						},
+					},
+					Workspace: &aerospacecli.Workspace{
+						Workspace: "ws2",
+					},
+					FocusedWindowId: 91011,
+				},
+			}
+
+			allWindows := testutils.ExtractAllWindows(tree)
+			focusedTree := testutils.ExtractFocusedTree(tree)
+			// focusedWindow := testutils.ExtractFocusedWindow(tree)
+
+			aerospaceClient := mock_aerospace.NewMockAeroSpaceClient(ctrl)
+			gomock.InOrder(
+				aerospaceClient.EXPECT().
+					GetAllWindows().
+					Return(allWindows, nil).
+					Times(1),
+
+				aerospaceClient.EXPECT().
+					GetFocusedWorkspace().
+					Return(focusedTree.Workspace, nil).
+					Times(1),
+
+				// Send first window
+				aerospaceClient.EXPECT().
+					MoveWindowToWorkspace(
+						tree[0].Windows[0].WindowID,
+						focusedTree.Workspace.Workspace,
+					).
+					Return(nil).
+					Times(1),
+				aerospaceClient.EXPECT().
+					SetFocusByWindowID(
+						tree[0].Windows[0].WindowID,
+					).
+					Return(nil).
+					Times(1),
+
+				// Send 2nd window
+				aerospaceClient.EXPECT().
+					MoveWindowToWorkspace(
+						tree[0].Windows[1].WindowID,
+						focusedTree.Workspace.Workspace,
+					).
+					Return(nil).
+					Times(1),
+				aerospaceClient.EXPECT().
+					SetFocusByWindowID(
+						tree[0].Windows[1].WindowID,
+					).
+					Return(nil).
+					Times(1),
+			)
+
+			cmd := RootCmd(aerospaceClient)
+			out, err := testutils.CmdExecute(cmd, args...)
+			if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+
+			if out == "" {
+				t.Errorf("Expected output, got empty string")
+			}
+
+			cmdAsString := "aerospace-scratchpad " + strings.Join(args, " ") + "\n"
+			expectedError := fmt.Sprintf("Error\n%+v", err)
+			snaps.MatchSnapshot(t, tree, cmdAsString, "Output", out, expectedError)
+		})
+
+		tt.Run("sends all windows to scratchpad if at least one window is focused", func(t *testing.T) {
+			command := "show"
+			args := []string{command, "Finder"}
+
+			ctrl := gomock.NewController(tt)
+			defer ctrl.Finish()
+
+			tree := []testutils.AeroSpaceTree{
+				{
+					Windows: []aerospacecli.Window{},
+					Workspace: &aerospacecli.Workspace{
+						Workspace: "ws1",
+					},
+					FocusedWindowId: 0, // Not focused
+				},
+				{
+					Windows: []aerospacecli.Window{
+						{
+							AppName:   "Finder1",
+							WindowID:  5678,
+							Workspace: "ws2",
+						},
+						{
+							AppName:   "Finder2",
+							WindowID:  5679,
+							Workspace: "ws2",
+						},
+						{
+							AppName:   "Terminal",
+							WindowID:  91011,
+							Workspace: "ws2",
+						},
+					},
+					Workspace: &aerospacecli.Workspace{
+						Workspace: "ws2",
+					},
+					FocusedWindowId: 5678,
+				},
+			}
+
+			allWindows := testutils.ExtractAllWindows(tree)
+			focusedTree := testutils.ExtractFocusedTree(tree)
+			focusedWindow := testutils.ExtractFocusedWindow(tree)
+
+			aerospaceClient := mock_aerospace.NewMockAeroSpaceClient(ctrl)
+			gomock.InOrder(
+				aerospaceClient.EXPECT().
+					GetAllWindows().
+					Return(allWindows, nil).
+					Times(1),
+
+				aerospaceClient.EXPECT().
+					GetFocusedWorkspace().
+					Return(focusedTree.Workspace, nil).
+					Times(1),
+
+				aerospaceClient.EXPECT().
+					GetFocusedWindow().
+					Return(focusedWindow, nil).
+					Times(2),
+
+				aerospaceClient.EXPECT().
+					SetFocusByWindowID(
+						tree[1].Windows[0].WindowID,
+					).
+					Return(nil).
+					Times(1),
+
+				aerospaceClient.EXPECT().
+					SetFocusByWindowID(
+						tree[1].Windows[1].WindowID,
+					).
+					Return(nil).
+					Times(1),
+			)
+
+			cmd := RootCmd(aerospaceClient)
+			out, err := testutils.CmdExecute(cmd, args...)
+			if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+
+			if out == "" {
+				t.Errorf("Expected output, got empty string")
+			}
+
+			cmdAsString := "aerospace-scratchpad " + strings.Join(args, " ") + "\n"
+			expectedError := fmt.Sprintf("Error\n%+v", err)
+			snaps.MatchSnapshot(t, tree, cmdAsString, "Output", out, expectedError)
+		})
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cristianoliveira/aerospace-scratchpad
 go 1.24.2
 
 require (
-	github.com/cristianoliveira/aerospace-ipc v0.0.3-0.20250529132745-71cbb876fffa // indirect
+	github.com/cristianoliveira/aerospace-ipc v0.0.3 // indirect
 	github.com/gkampitakis/ciinfo v0.3.1 // indirect
 	github.com/gkampitakis/go-diff v1.3.2 // indirect
 	github.com/gkampitakis/go-snaps v0.5.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cristianoliveira/aerospace-ipc v0.0.2-0.20250529122618-e3e73beb5263 h
 github.com/cristianoliveira/aerospace-ipc v0.0.2-0.20250529122618-e3e73beb5263/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
 github.com/cristianoliveira/aerospace-ipc v0.0.3-0.20250529132745-71cbb876fffa h1:YhsiLDrlamY5X5SGQg4QGKZU4O94QRUs9QUfQuT/Sug=
 github.com/cristianoliveira/aerospace-ipc v0.0.3-0.20250529132745-71cbb876fffa/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
+github.com/cristianoliveira/aerospace-ipc v0.0.3 h1:v9VGyPxT6tRAdKgWl9p+HUVpFJM88bw6sz5OH845qqE=
+github.com/cristianoliveira/aerospace-ipc v0.0.3/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
 github.com/gkampitakis/ciinfo v0.3.1 h1:lzjbemlGI4Q+XimPg64ss89x8Mf3xihJqy/0Mgagapo=
 github.com/gkampitakis/ciinfo v0.3.1/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=


### PR DESCRIPTION
This commit allows scratchpad handling multiple windows matching.
Example, when there are 2 or more Finder opened

Using Finder as example:

aerospace-scratchpad show Finder

Show command

 - If all Finders are in the focused workspace, send all them to
   scratchpad
 - If all Finders are in scratchpad, summon all them to current
   workspace
 - If one or more Finders are not in the focused workspace, it will
   bring all to focused workspace

Move command

 - Moves all finders to scratchpad

Summon command

 - Summon all windows to focused workspace
 

## Demo

https://github.com/user-attachments/assets/96ca9375-d561-4240-8f36-4899c4b90142


 