### PR TITLE
feat(logs): introduce logging capabilities

### DIFF
--- a/cmd/move_test.go
+++ b/cmd/move_test.go
@@ -7,6 +7,7 @@ import (
 
 	aerospacecli "github.com/cristianoliveira/aerospace-ipc"
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/constants"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/logger"
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/mocks/aerospacecli"
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/testutils"
 	"github.com/gkampitakis/go-snaps/snaps"
@@ -14,6 +15,8 @@ import (
 )
 
 func TestMoveCmd(t *testing.T) {
+	logger.SetDefaultLogger(&logger.EmptyLogger{})
+
 	t.Run("moves current focused window to scratchpad when empty", func(t *testing.T) {
 		command := "move"
 		args := []string{command, ""}

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -7,6 +7,7 @@ import (
 
 	aerospacecli "github.com/cristianoliveira/aerospace-ipc"
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/constants"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/logger"
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/mocks/aerospacecli"
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/stderr"
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/testutils"
@@ -15,6 +16,8 @@ import (
 )
 
 func TestShowCmd(t *testing.T) {
+	logger.SetDefaultLogger(&logger.EmptyLogger{})
+
 	t.Run("fails when pattern is empty", func(t *testing.T) {
 		command := "show"
 		args := []string{command, ""}

--- a/internal/constants/environment.go
+++ b/internal/constants/environment.go
@@ -1,0 +1,16 @@
+package constants
+
+// Define here all environment variables used in the application
+
+const (
+	// EnvAeroSpaceScratchpadLogsPath is the environment variable for the AeroSpace marks logs path
+	// default: `/tmp/aerospace-scratchpad.log`
+	EnvAeroSpaceScratchpadLogsPath string = "AEROSPACE_SCRATCHPAD_LOGS_PATH"
+
+	// EnvAeroSpaceScratchpadLogsLevel is the environment variable for the AeroSpace marks logs level
+	// default: `DISABLED`
+	EnvAeroSpaceScratchpadLogsLevel string = "AEROSPACE_SCRATCHPAD_LOGS_LEVEL"
+
+	// EnvAeroSpaceSock is the environment variable for the AeroSpace IPC socket path
+	EnvAeroSpaceSock string = "AEROSPACESOCK"
+)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,168 @@
+package logger
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/constants"
+)
+
+var defaultLogger Logger
+
+type LogConfig struct {
+	// Path to the log file
+	Path string `json:"path"`
+	// Log level
+	Level string `json:"level"`
+}
+
+type Logger interface {
+	// Info logs an informational message
+	LogInfo(msg string, args ...any)
+	// Error logs an error message
+	LogError(msg string, args ...any)
+	// Debug logs a debug message
+	LogDebug(msg string, args ...any)
+
+	// GetConfig returns the logger configuration
+	GetConfig() LogConfig
+
+	// AsJson returns the logger as a JSON object
+	// In error, logs the error and returns an empty string
+	AsJson(data any) string
+
+	// Close closes the logger
+	Close() error
+}
+
+type LoggerClient struct {
+	logger *slog.Logger
+	file   *os.File
+	config LogConfig
+}
+
+func (l *LoggerClient) LogInfo(msg string, args ...any) {
+	l.logger.Info(msg, args...)
+}
+
+func (l *LoggerClient) LogError(msg string, args ...any) {
+	l.logger.Error(msg, args...)
+}
+
+func (l *LoggerClient) LogDebug(msg string, args ...any) {
+	l.logger.Debug(msg, args...)
+}
+
+func (l *LoggerClient) GetConfig() LogConfig {
+	return l.config
+}
+
+func (l *LoggerClient) AsJson(data any) string {
+	json, err := json.Marshal(data)
+	if err != nil {
+		l.LogError("failed to marshal data to JSON", err)
+		return ""
+	}
+	return string(json)
+}
+
+func (l *LoggerClient) Close() error {
+	if l.file != nil {
+		err := l.file.Close()
+		if err != nil {
+			return fmt.Errorf("failed to close log file: %v", err)
+		}
+	}
+	return nil
+}
+
+type EmptyLogger struct{}
+
+func (l *EmptyLogger) LogInfo(msg string, args ...any) {
+	// No-op
+}
+func (l *EmptyLogger) LogError(msg string, args ...any) {
+	// No-op
+}
+func (l *EmptyLogger) LogDebug(msg string, args ...any) {
+	// No-op
+}
+func (l *EmptyLogger) Close() error {
+	// No-op
+	return nil
+}
+func (l *EmptyLogger) GetConfig() LogConfig {
+	// No-op
+	return LogConfig{
+		Path:  "/tmp/aerospace-marks.log",
+		Level: "DISABLED",
+	}
+}
+func (l *EmptyLogger) AsJson(data any) string {
+	// No-op
+	return ""
+}
+
+// NewLogger creates a new logger instance
+// It accepts a path to a file where logs will be written
+// and a boolean indicating whether to log to stdout as well
+func NewLogger() (Logger, error) {
+	path := os.Getenv(constants.EnvAeroSpaceScratchpadLogsPath)
+	if path == "" {
+		path = "/tmp/aerospace-scratchpad.log"
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log file: %v", err)
+	}
+
+	configLogLevel := os.Getenv(constants.EnvAeroSpaceScratchpadLogsLevel)
+	if configLogLevel == "" {
+		return &EmptyLogger{}, nil
+	}
+
+	logLevel := slog.LevelError
+	if configLogLevel != "" {
+		switch configLogLevel {
+		case "DEBUG":
+			logLevel = slog.LevelDebug
+		case "INFO":
+			logLevel = slog.LevelInfo
+		case "WARN":
+			logLevel = slog.LevelWarn
+		default:
+			logLevel = slog.LevelError
+		}
+	}
+
+	textHandler := slog.NewTextHandler(file, &slog.HandlerOptions{
+		Level: logLevel,
+	})
+
+	newLogger := slog.New(textHandler)
+	logClient := &LoggerClient{
+		logger: newLogger,
+		file:   file,
+		config: LogConfig{
+			Path:  path,
+			Level: configLogLevel,
+		},
+	}
+
+	return logClient, nil
+}
+
+func SetDefaultLogger(logger Logger) {
+	// Set the default logger to the provided logger
+	defaultLogger = logger
+}
+
+func GetDefaultLogger() Logger {
+	if defaultLogger == nil {
+		panic("Unrecoverable error because default logger is not set")
+	}
+	return defaultLogger
+}

--- a/internal/stderr/print.go
+++ b/internal/stderr/print.go
@@ -3,6 +3,8 @@ package stderr
 import (
 	"fmt"
 	"os"
+
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/logger"
 )
 
 // This package contains functions to print errors in a consistent way.
@@ -15,6 +17,9 @@ func SetBehavior(shouldExit bool) {
 }
 
 func Writef(tmpl string, a ...any) {
+	logger := logger.GetDefaultLogger()
+	logger.LogError(fmt.Sprintf(tmpl, a...))
+
 	errorMessage := fmt.Errorf(tmpl, a...)
 	_, err := fmt.Fprintln(os.Stderr, errorMessage)
 	if err != nil {
@@ -28,6 +33,9 @@ func Writef(tmpl string, a ...any) {
 // Println prints an error message to stderr and exits the program if ShouldExit is true.
 // Why not use log.Fatalf? Because we want to control the exit behavior.
 func Println(tmpl string, a ...any) {
+	logger := logger.GetDefaultLogger()
+	logger.LogError(fmt.Sprintf(tmpl, a...))
+
 	errorMessage := fmt.Errorf(tmpl, a...)
 	_, err := fmt.Fprintln(os.Stderr, errorMessage)
 	if err != nil {
@@ -39,6 +47,9 @@ func Println(tmpl string, a ...any) {
 }
 
 func Printf(tmpl string, a ...any) {
+	logger := logger.GetDefaultLogger()
+	logger.LogError(fmt.Sprintf(tmpl, a...))
+
 	_, err := fmt.Fprintf(os.Stderr, tmpl, a...)
 	if err != nil {
 		panic(fmt.Sprintf("Failure: unable to print error message: %v", err))

--- a/main.go
+++ b/main.go
@@ -5,12 +5,27 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	aerospacecli "github.com/cristianoliveira/aerospace-ipc"
 	"github.com/cristianoliveira/aerospace-scratchpad/cmd"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/logger"
 )
 
 func main() {
+	defaultLogger, err := logger.NewLogger()
+	if err != nil {
+		log.Fatalf("Error: creating logger\n%v", err)
+		return
+	}
+	defer func() {
+		if err := defaultLogger.Close(); err != nil {
+			log.Fatalf("Error: closing logger\n%v", err)
+		}
+	}()
+	logger.SetDefaultLogger(defaultLogger)
+	defaultLogger.LogInfo("Executing Aerospace Scratchpad CLI")
+
 	aerospaceMarkClient, err := aerospacecli.NewAeroSpaceConnection()
 	if err != nil {
 		fmt.Println("Error creating Aerospace client:", err)


### PR DESCRIPTION
Summary:
This commit introduces a new logging capability to /tmp/aerospace-scratchpad.log

Detailed Changes:
 - cmd/move.go: cmd/show.go:
   - Added logging at various steps of the move command to trace execution and error handling.
   - Imported new logger package.
   - Implemented logging to monitor show command execution.
   - Imported logger package.
 - internal/constants/environment.go:
   - Introduced environment constants for log path and level.
 - internal/logger/logger.go:
   - Implemented a new logger package for structured logging.
 - internal/stderr/print.go:
   - Integrated logging for standard error prints.