### PR TITLE
fix(cmd): ensure windows are correctly sent to scratchpad

### DIFF
--- a/cmd/__snapshots__/show_test.snap
+++ b/cmd/__snapshots__/show_test.snap
@@ -222,8 +222,8 @@ Error
 aerospace-scratchpad show Finder
 
 Output
-Window '5678 | Finder1  | ws2' is focused
-Window '5679 | Finder2  | ws2' is focused
+Window '5678 | Finder1  | ws2' hidden to scratchpad
+Window '5679 | Finder2  | ws2' hidden to scratchpad
 
 Error
 <nil>

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -104,11 +104,19 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 						return
 					}
 
-					shouldSendToScratchpad = isWindowFocused
+					// Make sure that once shouldSendToScratchpad is true, it will remain true
+					shouldSendToScratchpad = shouldSendToScratchpad || isWindowFocused
 				} else {
 					windowsOutsideView = append(windowsOutsideView, window)
 
 				}
+
+				logger.LogDebug(
+					"SHOW: loop",
+					"windowsOutsideView", windowsOutsideView,
+					"windowsInFocusedWorkspace", windowsInFocusedWorkspace,
+					"shouldSendToScratchpad", shouldSendToScratchpad,
+				)
 			}
 
 			logger.LogDebug(

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -492,15 +492,31 @@ func TestShowCmd(t *testing.T) {
 					Times(2),
 
 				aerospaceClient.EXPECT().
-					SetFocusByWindowID(
+					MoveWindowToWorkspace(
 						tree[1].Windows[0].WindowID,
+						constants.DefaultScratchpadWorkspaceName,
+					).
+					Return(nil).
+					Times(1),
+				aerospaceClient.EXPECT().
+					SetLayout(
+						tree[1].Windows[0].WindowID,
+						"floating",
 					).
 					Return(nil).
 					Times(1),
 
 				aerospaceClient.EXPECT().
-					SetFocusByWindowID(
+					MoveWindowToWorkspace(
 						tree[1].Windows[1].WindowID,
+						constants.DefaultScratchpadWorkspaceName,
+					).
+					Return(nil).
+					Times(1),
+				aerospaceClient.EXPECT().
+					SetLayout(
+						tree[1].Windows[1].WindowID,
+						"floating",
 					).
 					Return(nil).
 					Times(1),


### PR DESCRIPTION
Summary:
This commit fixes the logic to correctly send windows to the scratchpad instead of setting focus, preventing unintended window behaviors. Fixes #38

Detailed Changes:
 - cmd/show.go:
   - Modified logic to ensure windows intended to be hidden are correctly sent to the scratchpad.
   - Added debugging logs to trace variable states during execution.
 - cmd/show_test.go:
   - Updated test expectations to reflect corrections in window management, moving windows to the scratchpad workspace and setting them to floating layout.