### PR TITLE
fix(cmd): fails no matching windows pattern with exit 1 

### DIFF
--- a/cmd/__snapshots__/move_test.snap
+++ b/cmd/__snapshots__/move_test.snap
@@ -1,11 +1,42 @@
 
-[TestMoveCmd/fails_when_missing_or_empty_arguments - 1]
-aerospace-scratchpad move 
+[TestMoveCmd/fails_when_pattern_doesnt_match_any_window - 1]
+[]testutils.AeroSpaceTree{
+    {
+        Windows: {
+            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
+        FocusedWindowId: 5678,
+    },
+}
+aerospace-scratchpad move foo
 
 Output
 
 Error
-argument at position 0 is empty or whitespace
+ no windows matched the pattern 'foo'
+
+---
+
+[TestMoveCmd/moves_current_focused_window_to_scratchpad_when_empty - 1]
+[]testutils.AeroSpaceTree{
+    {
+        Windows: {
+            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
+        FocusedWindowId: 5678,
+    },
+}
+aerospace-scratchpad move 
+
+Output
+Moving window 5678 | Finder  to scratchpad
+
+Error
+ <nil>
 ---
 
 [TestMoveCmd/fails_when_getting_all_windows_return_an_erro - 1]
@@ -14,7 +45,8 @@ aerospace-scratchpad move test
 Output
 
 Error
-unable to get windows
+ unable to get windows
+
 ---
 
 [TestMoveCmd/moves_a_window_to_scratchpad_by_pattern - 1]
@@ -37,7 +69,6 @@ Error
  <nil>
 ---
 
-
 [TestMoveCmd/fails_when_moving_a_window_to_scratchpad - 1]
 []testutils.AeroSpaceTree{
     {
@@ -55,24 +86,5 @@ Output
 
 Error
 unable to move window '5678 | Finder ' to scratchpad
----
 
-[TestMoveCmd/moves_current_focused_window_to_scratchpad_when_empty - 1]
-[]testutils.AeroSpaceTree{
-    {
-        Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
-        },
-        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
-        FocusedWindowId: 5678,
-    },
-}
-aerospace-scratchpad move 
-
-Output
-Moving window 5678 | Finder  to scratchpad
-
-Error
- <nil>
 ---

--- a/cmd/__snapshots__/show_test.snap
+++ b/cmd/__snapshots__/show_test.snap
@@ -286,3 +286,23 @@ Window '5679 | Finder2  | ws2' is focused
 Error
 <nil>
 ---
+
+[TestShowCmd/fails_when_pattern_doesn_match_any_window - 1]
+[]testutils.AeroSpaceTree{
+    {
+        Windows: {
+            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
+        FocusedWindowId: 1234,
+    },
+}
+aerospace-scratchpad show foo
+
+Output
+Error: no windows found matching the pattern
+
+Error
+<nil>
+---

--- a/cmd/__snapshots__/show_test.snap
+++ b/cmd/__snapshots__/show_test.snap
@@ -1,25 +1,5 @@
 
-[TestFunction/set_focus_to_window_if_already_in_the_focused_workspace_but_not_focused - 1]
-[]testutils.AeroSpaceTree{
-    {
-        Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
-        },
-        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
-        FocusedWindowId: 1234,
-    },
-}
-aerospace-scratchpad show Finder
-
-Output
-Window '5678 | Finder ' is showed
-
-Error
-<nil>
----
-
-[TestFunction/moves_a_window_to_scratchpad_by_pattern - 1]
+[TestShowCmd/fails_when_pattern_is_empty - 1]
 []testutils.AeroSpaceTree{
     {
         Windows: {
@@ -30,16 +10,16 @@ Error
         FocusedWindowId: 5678,
     },
 }
-aerospace-scratchpad show Finder
+aerospace-scratchpad show 
 
 Output
-Window '5678 | Finder ' hidden to scratchpad
 
 Error
-<nil>
+Error: <pattern> cannot be empty
+
 ---
 
-[TestFunction/summon_the_window_to_the_current_workspace_if_in_another_workspace - 1]
+[TestShowCmd/fails_when_pattern_doesn_match_any_window - 1]
 []testutils.AeroSpaceTree{
     {
         Windows: {
@@ -47,23 +27,16 @@ Error
             {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &aerospace.Workspace{Workspace:"ws1"},
-        FocusedWindowId: 0,
-    },
-    {
-        Windows: {
-            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:""},
-        },
-        Workspace:       &aerospace.Workspace{Workspace:"ws2"},
-        FocusedWindowId: 91011,
+        FocusedWindowId: 1234,
     },
 }
-aerospace-scratchpad show Finder
+aerospace-scratchpad show foo
 
 Output
-Window '5678 | Finder ' is summoned
 
 Error
-<nil>
+Error: no windows found matching the pattern
+
 ---
 
 [TestShowCmd/set_focus_to_window_if_already_in_the_focused_workspace_but_not_focused - 1]
@@ -128,46 +101,6 @@ aerospace-scratchpad show Finder
 
 Output
 Window '5678 | Finder ' is summoned
-
-Error
-<nil>
----
-
-[TestShowCmd/moves_the_current_focused_window_to_scratchpad_when_empty - 1]
-[]testutils.AeroSpaceTree{
-    {
-        Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
-        },
-        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
-        FocusedWindowId: 5678,
-    },
-}
-aerospace-scratchpad show 
-
-Output
-
-Error
-<nil>
----
-
-
-[TestShowCmd/fails_when_pattern_is_empty - 1]
-[]testutils.AeroSpaceTree{
-    {
-        Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
-        },
-        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
-        FocusedWindowId: 5678,
-    },
-}
-aerospace-scratchpad show 
-
-Output
-Error: <pattern> cannot be empty
 
 Error
 <nil>
@@ -282,26 +215,6 @@ aerospace-scratchpad show Finder
 Output
 Window '5678 | Finder1  | ws1' is summoned
 Window '5679 | Finder2  | ws2' is focused
-
-Error
-<nil>
----
-
-[TestShowCmd/fails_when_pattern_doesn_match_any_window - 1]
-[]testutils.AeroSpaceTree{
-    {
-        Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
-        },
-        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
-        FocusedWindowId: 1234,
-    },
-}
-aerospace-scratchpad show foo
-
-Output
-Error: no windows found matching the pattern
 
 Error
 <nil>

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -143,6 +143,11 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 				}
 			}
 
+			if len(windowsInFocusedWorkspace) == 0 && len(windowsOutsideView) == 0 {
+				stderr.Println("Error: no windows found matching the pattern")
+				return
+			}
+
 			// NOTE: To avoid the ping pong of windows, so priority is
 			// for bringing windows to the focused workspace
 			if len(windowsOutsideView) > 0 {

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -50,12 +50,8 @@ func TestShowCmd(t *testing.T) {
 		aerospaceClient := mock_aerospace.NewMockAeroSpaceClient(ctrl)
 		cmd := RootCmd(aerospaceClient)
 		out, err := testutils.CmdExecute(cmd, args...)
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
-		}
-
-		if out == "" {
-			t.Errorf("Expected output, got empty string")
+		if err == nil {
+			t.Errorf("Expected error, got %v", out)
 		}
 
 		cmdAsString := "aerospace-scratchpad " + strings.Join(args, " ") + "\n"
@@ -108,12 +104,8 @@ func TestShowCmd(t *testing.T) {
 
 		cmd := RootCmd(aerospaceClient)
 		out, err := testutils.CmdExecute(cmd, args...)
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
-		}
-
-		if out == "" {
-			t.Errorf("Expected output, got empty string")
+		if err == nil {
+			t.Errorf("Expected error, got %v", out)
 		}
 
 		cmdAsString := "aerospace-scratchpad " + strings.Join(args, " ") + "\n"

--- a/internal/testutils/logger.go
+++ b/internal/testutils/logger.go
@@ -4,8 +4,7 @@ import (
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/logger"
 )
 
-
-type TestingLogger struct{
+type TestingLogger struct {
 	Logger func(msg string, args ...any)
 }
 
@@ -33,5 +32,3 @@ func (l *TestingLogger) AsJson(data any) string {
 	// No-op
 	return ""
 }
-
-

--- a/internal/testutils/logger.go
+++ b/internal/testutils/logger.go
@@ -1,0 +1,37 @@
+package testutils
+
+import (
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/logger"
+)
+
+
+type TestingLogger struct{
+	Logger func(msg string, args ...any)
+}
+
+func (l *TestingLogger) LogInfo(msg string, args ...any) {
+	l.Logger(msg, args...)
+}
+func (l *TestingLogger) LogError(msg string, args ...any) {
+	l.Logger(msg, args...)
+}
+func (l *TestingLogger) LogDebug(msg string, args ...any) {
+	l.Logger(msg, args...)
+}
+func (l *TestingLogger) Close() error {
+	// No-op
+	return nil
+}
+func (l *TestingLogger) GetConfig() logger.LogConfig {
+	// No-op
+	return logger.LogConfig{
+		Path:  "/tmp/aerospace-marks.log",
+		Level: "DISABLED",
+	}
+}
+func (l *TestingLogger) AsJson(data any) string {
+	// No-op
+	return ""
+}
+
+


### PR DESCRIPTION
Fix #55 

Summary:

This commit fixes a bug in the `show` command that does not handle cases where no windows match the provided pattern, returning exit 1

Detailed Changes:
- cmd/show.go:
  - Added a check to print an error message if no windows match the provided pattern and exit the function early.
- cmd/show_test.go:
  - Added a new test case to verify that the `show` command fails gracefully with an appropriate error message when no windows match the pattern.
- cmd/__snapshots__/show_test.snap:
  - Updated snapshot with new test case for the scenario where no windows match the pattern, capturing the error output.