### PR TITLE
feat: enable dry-run for all commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	aerospacecli "github.com/cristianoliveira/aerospace-ipc"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/aerospace"
 	"github.com/spf13/cobra"
 )
 
@@ -28,12 +29,24 @@ https://i3wm.org/docs/userguide.html#_scratchpad
 		Version: VERSION,
 	}
 
+	// Global Flags
+	rootCmd.PersistentFlags().BoolP("dry-run", "d", false, "Run the command without moving windows (dry run mode)")
+
+	// Create custom client with custom options
+	customClient := aerospace.NewAeroSpaceClient(aerospaceClient)
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		dry, _ := cmd.Flags().GetBool("dry-run")
+		customClient.SetOptions(aerospace.AeroSpaceClientOpts{
+			DryRun: dry,
+		})
+	}
+
 	// Commands
-	rootCmd.AddCommand(MoveCmd(aerospaceClient))
-	rootCmd.AddCommand(ShowCmd(aerospaceClient))
-	rootCmd.AddCommand(SummonCmd(aerospaceClient))
-	rootCmd.AddCommand(NextCmd(aerospaceClient))
-	rootCmd.AddCommand(InfoCmd(aerospaceClient))
+	rootCmd.AddCommand(MoveCmd(customClient))
+	rootCmd.AddCommand(ShowCmd(customClient))
+	rootCmd.AddCommand(SummonCmd(customClient))
+	rootCmd.AddCommand(NextCmd(customClient))
+	rootCmd.AddCommand(InfoCmd(customClient))
 
 	return rootCmd
 }
@@ -42,8 +55,8 @@ func Execute(
 	aerospaceClient aerospacecli.AeroSpaceClient,
 ) {
 	rootCmd := RootCmd(aerospaceClient)
-	err := rootCmd.Execute()
-	if err != nil {
+
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ https://i3wm.org/docs/userguide.html#_scratchpad
 	}
 
 	// Global Flags
-	rootCmd.PersistentFlags().BoolP("dry-run", "d", false, "Run the command without moving windows (dry run mode)")
+	rootCmd.PersistentFlags().BoolP("dry-run", "n", false, "Run the command without moving windows (dry run mode)")
 
 	// Create custom client with custom options
 	customClient := aerospace.NewAeroSpaceClient(aerospaceClient)

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,20 @@ This command will summon the next window from the scratchpad workspace until the
 aerospace-scratchpad next
 ```
 
+## Global flags
+
+### `--dry-run|-d` Dry Run
+
+This flag will not execute the command, but will print what would be done. Very handy to test your command before adding to your
+config file.
+
+Usage:
+```bash
+aerospace-scratchpad --dry-run show <pattern>
+```
+
+It will print the actions that would be taken, but will not execute them.
+
 ## Implementation details
 
 ### Scratchpad workspace

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@ aerospace-scratchpad next
 
 ## Global flags
 
-### `--dry-run|-d` Dry Run
+### `--dry-run|-n` Dry Run
 
 This flag will not execute the command, but will print what would be done. Very handy to test your command before adding to your
 config file.

--- a/internal/aerospace/client.go
+++ b/internal/aerospace/client.go
@@ -1,0 +1,85 @@
+package aerospace
+
+import (
+	"fmt"
+
+	aerospacecli "github.com/cristianoliveira/aerospace-ipc"
+	socketcli "github.com/cristianoliveira/aerospace-ipc/pkg/client"
+)
+
+// AeroSpaceClient implements the AeroSpaceClient interface for interacting with AeroSpaceWM.
+type AeroSpaceClient struct {
+	ogClient aerospacecli.AeroSpaceClient
+	dryRun   bool
+}
+
+// AeroSpaceClientOpts defines options for creating a new AeroSpaceClient.
+type AeroSpaceClientOpts struct {
+	DryRun bool
+}
+
+// NewAeroSpaceClient creates a new AeroSpaceClient with the default settings.
+func NewAeroSpaceClient(client aerospacecli.AeroSpaceClient) *AeroSpaceClient {
+	return &AeroSpaceClient{
+		ogClient: client,
+		dryRun:   false, // Default dry-run is false
+	}
+}
+
+// SetOptionssets the dry-run flag for the AeroSpaceClient.
+func (c *AeroSpaceClient) SetOptions(opts AeroSpaceClientOpts) {
+	c.dryRun = opts.DryRun
+}
+
+// All methods
+func (c *AeroSpaceClient) GetAllWindows() ([]aerospacecli.Window, error) {
+	return c.ogClient.GetAllWindows()
+}
+
+func (c *AeroSpaceClient) GetAllWindowsByWorkspace(workspaceName string) ([]aerospacecli.Window, error) {
+	return c.ogClient.GetAllWindowsByWorkspace(workspaceName)
+}
+
+func (c *AeroSpaceClient) GetFocusedWindow() (*aerospacecli.Window, error) {
+	return c.ogClient.GetFocusedWindow()
+}
+
+func (c *AeroSpaceClient) SetFocusByWindowID(windowID int) error {
+	if c.dryRun {
+		fmt.Printf("[dry-run] SetFocusByWindowID(%d)\n", windowID)
+		return nil
+	}
+	return c.ogClient.SetFocusByWindowID(windowID)
+}
+
+func (c *AeroSpaceClient) GetFocusedWorkspace() (*aerospacecli.Workspace, error) {
+	return c.ogClient.GetFocusedWorkspace()
+}
+
+func (c *AeroSpaceClient) MoveWindowToWorkspace(windowID int, workspaceName string) error {
+	if c.dryRun {
+		fmt.Printf("[dry-run] MoveWindowToWorkspace(windowID=%d, workspace=%s)\n", windowID, workspaceName)
+		return nil
+	}
+	return c.ogClient.MoveWindowToWorkspace(windowID, workspaceName)
+}
+
+func (c *AeroSpaceClient) SetLayout(windowID int, layout string) error {
+	if c.dryRun {
+		fmt.Printf("[dry-run] SetLayout(windowID=%d, layout=%s)\n", windowID, layout)
+		return nil
+	}
+	return c.ogClient.SetLayout(windowID, layout)
+}
+
+func (c *AeroSpaceClient) Connection() socketcli.AeroSpaceConnection {
+	return c.ogClient.Connection()
+}
+
+func (c *AeroSpaceClient) CloseConnection() error {
+	if c.dryRun {
+		fmt.Println("[dry-run] CloseConnection()")
+		return nil
+	}
+	return c.ogClient.CloseConnection()
+}


### PR DESCRIPTION
Summary:
Introduced a new custom client for interacting with AeroSpaceWM, allowing the execution of commands in dry-run mode.

Close #68 

Detailed Changes:
 - cmd/root.go:
   - Imported new aerospace package and added a dry-run flag to execute commands without moving windows.
   - Replaced default client with `customClient` for command execution.
 - docs/README.md:
   - Added documentation for the new dry-run feature and its usage.
 - internal/aerospace/client.go:
   - Created a new `AeroSpaceClient` with an optional dry-run mode for client operations.