### PR TITLE
refactor: centralize filter flag configuration to ensure consistency

### DIFF
--- a/cmd/move.go
+++ b/cmd/move.go
@@ -104,9 +104,5 @@ If no pattern is provided, it moves the currently focused window.
 			}
 		},
 	}
-
-	// Filter flags --filter
-	command.Flags().StringArrayP("filter", "F", []string{}, "Filter windows by a specific property (e.g., app-name, window-title). Can be used multiple times.")
-
 	return command
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,13 +42,22 @@ https://i3wm.org/docs/userguide.html#_scratchpad
 	}
 
 	// Commands
-	rootCmd.AddCommand(MoveCmd(customClient))
-	rootCmd.AddCommand(ShowCmd(customClient))
-	rootCmd.AddCommand(SummonCmd(customClient))
+	rootCmd.AddCommand(enableFilterFlag(MoveCmd(customClient)))
+	rootCmd.AddCommand(enableFilterFlag(ShowCmd(customClient)))
+	rootCmd.AddCommand(enableFilterFlag(SummonCmd(customClient)))
 	rootCmd.AddCommand(NextCmd(customClient))
 	rootCmd.AddCommand(InfoCmd(customClient))
 
 	return rootCmd
+}
+
+func enableFilterFlag(command *cobra.Command) *cobra.Command {
+	command.Flags().StringArrayP(
+		"filter", "F", []string{},
+		`Filter windows by a specific property (e.g. window-title=^foo).
+Requires a key=value format. Can be used multiple times. `,
+	)
+	return command
 }
 
 func Execute(

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -182,9 +182,5 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 			}
 		},
 	}
-
-	// Filter flags --filter
-	command.Flags().StringArrayP("filter", "F", []string{}, "Filter windows by a specific property (e.g., app-name, window-title). Can be used multiple times.")
-
 	return command
 }

--- a/cmd/summon.go
+++ b/cmd/summon.go
@@ -70,9 +70,5 @@ If no pattern is provided, it summons the first window in the scratchpad.
 			}
 		},
 	}
-
-	// Filter flags --filter
-	command.Flags().StringArrayP("filter", "F", []string{}, "Filter windows by a specific property (e.g., app-name, window-title). Can be used multiple times.")
-
 	return command
 }


### PR DESCRIPTION
Summary:
This commit centralizes the configuration of the --filter flag across multiple command files by introducing a helper function `enableFilterFlag`.

Detailed Changes:
 - cmd/move.go:
   - Removed inline filter flag configuration.
 - cmd/root.go:
   - Added `enableFilterFlag` function to centrally configure the filter flag.
   - Updated command additions to use `enableFilterFlag` for Move, Show, and Summon commands.
 - cmd/show.go:
   - Removed inline filter flag configuration.
 - cmd/summon.go:
   - Removed inline filter flag configuration.