### PR TITLE
fix(move): when no pattern only the focused window is moved

### DIFF
--- a/cmd/__snapshots__/move_test.snap
+++ b/cmd/__snapshots__/move_test.snap
@@ -114,3 +114,24 @@ Window '1234 | Notepad ' hidden to scratchpad
 Error
  <nil>
 ---
+
+[TestMoveCmd/moves_only_the_focused_window_when_multiple_matches_exist - 1]
+[]testutils.AeroSpaceTree{
+    {
+        Windows: {
+            {WindowID:1111, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
+        FocusedWindowID: 5678,
+    },
+}
+aerospace-scratchpad move 
+
+Output
+Moving window 5678 | Finder  to scratchpad
+Window '5678 | Finder ' hidden to scratchpad
+
+Error
+ <nil>
+---

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -37,6 +37,7 @@ If no pattern is provided, it moves the currently focused window.
 				windowNamePattern = strings.TrimSpace(args[0])
 			}
 
+			focusedWindowID := -1
 			if windowNamePattern == "" {
 				focusedWindow, err := aerospaceClient.GetFocusedWindow()
 				logger.LogDebug(
@@ -55,10 +56,12 @@ If no pattern is provided, it moves the currently focused window.
 					stderr.Println("Error: no focused window found")
 					return
 				}
+				focusedWindowID = focusedWindow.WindowID
 				windowNamePattern = fmt.Sprintf("^%s$", focusedWindow.AppName)
 				logger.LogDebug(
 					"MOVE: using focused window app name as pattern",
 					"windowNamePattern", windowNamePattern,
+					"focusedWindowId", focusedWindowID,
 				)
 			}
 
@@ -112,6 +115,16 @@ If no pattern is provided, it moves the currently focused window.
 			}
 
 			for _, window := range windows {
+				// FIXME: not sure this is the right place to do this check
+				if focusedWindowID != -1 && window.WindowID != focusedWindowID {
+					logger.LogDebug(
+						"MOVE: skipping window, not focused",
+						"window", window,
+						"focusedWindowId", focusedWindowID,
+					)
+					continue
+				}
+
 				// Move the window to the scratchpad
 				fmt.Fprintf(
 					os.Stdout,
@@ -134,5 +147,6 @@ If no pattern is provided, it moves the currently focused window.
 			}
 		},
 	}
+
 	return command
 }


### PR DESCRIPTION
## Problem

Today, the `move` command sends every match of the pattern for the given focused window, which is wrong. The idea is to move only this focused window, as the command description says. So, this fixes that problem. 