### PR TITLE
feat(move): allow moving all matching windows with --all

### DIFF
--- a/cmd/__snapshots__/move_test.snap
+++ b/cmd/__snapshots__/move_test.snap
@@ -135,3 +135,54 @@ Window '5678 | Finder ' hidden to scratchpad
 Error
  <nil>
 ---
+
+[TestMoveCmd/[dry-run]_moves_all_windows_with_the_same_app_name_as_the_focused_window_when_--all_is_used - 1]
+[]testutils.AeroSpaceTree{
+    {
+        Windows: {
+            {WindowID:1111, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
+        FocusedWindowID: 5678,
+    },
+}
+aerospace-scratchpad move  --all --dry-run
+
+Output
+[dry-run] FocusNextTilingWindow()
+Moving window 1111 | Finder  to scratchpad
+[dry-run] MoveWindowToWorkspace(windowID=1111, workspace=.scratchpad)
+[dry-run] SetLayout(windowID=1111, layout=floating)
+Window '1111 | Finder ' hidden to scratchpad
+Moving window 5678 | Finder  to scratchpad
+[dry-run] MoveWindowToWorkspace(windowID=5678, workspace=.scratchpad)
+[dry-run] SetLayout(windowID=5678, layout=floating)
+Window '5678 | Finder ' hidden to scratchpad
+
+Error
+ <nil>
+---
+
+[TestMoveCmd/moves_all_windows_with_the_same_app_name_as_the_focused_window_when_--all_is_used - 1]
+[]testutils.AeroSpaceTree{
+    {
+        Windows: {
+            {WindowID:1111, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+        },
+        Workspace:       &aerospace.Workspace{Workspace:"ws1"},
+        FocusedWindowID: 5678,
+    },
+}
+aerospace-scratchpad move  --all
+
+Output
+Moving window 1111 | Finder  to scratchpad
+Window '1111 | Finder ' hidden to scratchpad
+Moving window 5678 | Finder  to scratchpad
+Window '5678 | Finder ' hidden to scratchpad
+
+Error
+ <nil>
+---

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,11 @@ For more details:
 aerospace-scratchpad move --help
 ```
 
+To move all windows that match the focused window's app name to the scratchpad, you can use:
+```bash
+aerospace-scratchpad move --all 
+```
+
 See also [flags](#flags).
 
 ## Command: `show`

--- a/internal/testutils/aerospace.go
+++ b/internal/testutils/aerospace.go
@@ -69,3 +69,14 @@ func ExtractScratchpadWindows(tree []AeroSpaceTree) *AeroSpaceTree {
 	}
 	return nil
 }
+
+func ExtractWindowByID(tree []AeroSpaceTree, id int) *aerospacecli.Window {
+	for _, t := range tree {
+		for _, window := range t.Windows {
+			if window.WindowID == id {
+				return &window
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
To move all windows that match the focused window's app name to the scratchpad, you can use:
```bash
aerospace-scratchpad move --all 
```