### PR TITLE
refactor: change SetFocusByWindowID to SetFocus new interface

### DIFF
--- a/.watch.yaml
+++ b/.watch.yaml
@@ -6,8 +6,6 @@
 
 - name: quick checks
   run: 
-    - go fmt ./...
-    - make fmt
     - gotestsum --format pkgname
   run_on_init: true
   change: 
@@ -26,6 +24,19 @@
   change: 
     - '**/*.go'
     - '**/*.snap'
+  ignore: 
+    - '.tmp/**/*'
+    - '**/*.log'
+
+- name: quick checks style
+  run: 
+    - go fmt ./...
+    - make fmt
+  run_on_init: true
+  change: 
+    - '**/*.go'
+    - '**/*.snap'
+    - '.golangci.yml'
   ignore: 
     - '.tmp/**/*'
     - '**/*.log'

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/windows"
+	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/workspaces"
 	"github.com/cristianoliveira/aerospace-scratchpad/cmd"
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/aerospace"
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/constants"
@@ -46,7 +47,14 @@ func TestHookPullWindow(t *testing.T) {
 				Return(focusedWindow, nil).
 				Times(1),
 			mockClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(focusedWindow.WindowID, "prev-ws").
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: "prev-ws",
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &focusedWindow.WindowID,
+					},
+				).
 				Return(nil).
 				Times(1),
 		)

--- a/cmd/move_test.go
+++ b/cmd/move_test.go
@@ -60,10 +60,6 @@ func TestMoveCmd(t *testing.T) {
 			},
 		}
 		allWindows := testutils.ExtractAllWindows(tree)
-		windows := testutils.ExtractWindowsByName(tree, "Notepad")
-		if len(windows) != 1 {
-			t.Fatalf("Expected 1 Notepad window, got %d", len(windows))
-		}
 
 		aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
 		// Connection() is handled by routing connection, no need to mock
@@ -131,15 +127,26 @@ func TestMoveCmd(t *testing.T) {
 				Times(1),
 
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(
-					focusedWindow.WindowID,
-					constants.DefaultScratchpadWorkspaceName,
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: constants.DefaultScratchpadWorkspaceName,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &focusedWindow.WindowID,
+					},
 				).
 				Return(nil).
 				Times(1),
 
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayout(focusedWindow.WindowID, "floating").
+				SetLayoutWithOpts(
+					windows.SetLayoutArgs{
+						Layouts: []string{"floating"},
+					},
+					windows.SetLayoutOpts{
+						WindowID: &focusedWindow.WindowID,
+					},
+				).
 				Return(nil).
 				Times(1),
 		)
@@ -205,15 +212,26 @@ func TestMoveCmd(t *testing.T) {
 				Times(1),
 
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(
-					focusedWindow.WindowID,
-					constants.DefaultScratchpadWorkspaceName,
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: constants.DefaultScratchpadWorkspaceName,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &focusedWindow.WindowID,
+					},
 				).
 				Return(nil).
 				Times(1),
 
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayout(focusedWindow.WindowID, "floating").
+				SetLayoutWithOpts(
+					windows.SetLayoutArgs{
+						Layouts: []string{"floating"},
+					},
+					windows.SetLayoutOpts{
+						WindowID: &focusedWindow.WindowID,
+					},
+				).
 				Return(nil).
 				Times(1),
 		)
@@ -305,11 +323,11 @@ func TestMoveCmd(t *testing.T) {
 			},
 		}
 		allWindows := testutils.ExtractAllWindows(tree)
-		windows := testutils.ExtractWindowsByName(tree, "Notepad")
-		if len(windows) != 1 {
-			t.Fatalf("Expected 1 Notepad window, got %d", len(windows))
+		matchedWindows := testutils.ExtractWindowsByName(tree, "Notepad")
+		if len(matchedWindows) != 1 {
+			t.Fatalf("Expected 1 Notepad window, got %d", len(matchedWindows))
 		}
-		notepadWindow := windows[0]
+		notepadWindow := matchedWindows[0]
 
 		aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
 		// allow FocusNextTilingWindow to run without mocking Connection details
@@ -321,15 +339,26 @@ func TestMoveCmd(t *testing.T) {
 				Times(1),
 
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(
-					notepadWindow.WindowID,
-					constants.DefaultScratchpadWorkspaceName,
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: constants.DefaultScratchpadWorkspaceName,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &notepadWindow.WindowID,
+					},
 				).
 				Return(nil).
 				Times(1),
 
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayout(notepadWindow.WindowID, "floating").
+				SetLayoutWithOpts(
+					windows.SetLayoutArgs{
+						Layouts: []string{"floating"},
+					},
+					windows.SetLayoutOpts{
+						WindowID: &notepadWindow.WindowID,
+					},
+				).
 				Return(nil).
 				Times(1),
 		)
@@ -386,9 +415,13 @@ func TestMoveCmd(t *testing.T) {
 				Times(1),
 
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(
-					focusedWindow.WindowID,
-					constants.DefaultScratchpadWorkspaceName,
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: constants.DefaultScratchpadWorkspaceName,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &focusedWindow.WindowID,
+					},
 				).
 				Return(
 					fmt.Errorf(
@@ -399,7 +432,7 @@ func TestMoveCmd(t *testing.T) {
 				Times(1),
 
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayout(gomock.Any(), gomock.Any()).
+				SetLayoutWithOpts(gomock.Any(), gomock.Any()).
 				Return(nil).
 				Times(0),
 		)
@@ -444,11 +477,11 @@ func TestMoveCmd(t *testing.T) {
 			},
 		}
 		allWindows := testutils.ExtractAllWindows(tree)
-		windows := testutils.ExtractWindowsByName(tree, "Notepad")
-		if len(windows) != 1 {
-			t.Fatalf("Expected 1 Notepad window, got %d", len(windows))
+		matchedWindows := testutils.ExtractWindowsByName(tree, "Notepad")
+		if len(matchedWindows) != 1 {
+			t.Fatalf("Expected 1 Notepad window, got %d", len(matchedWindows))
 		}
-		notepadWindow := windows[0]
+		notepadWindow := matchedWindows[0]
 
 		aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
 		// allow wrapper.FocusNextTilingWindow in dry-run (will not call Connection)
@@ -460,15 +493,26 @@ func TestMoveCmd(t *testing.T) {
 				Times(1),
 
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(
-					notepadWindow.WindowID,
-					constants.DefaultScratchpadWorkspaceName,
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: constants.DefaultScratchpadWorkspaceName,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &notepadWindow.WindowID,
+					},
 				).
 				Return(nil).
 				Times(0), // DO NOT RUN
 
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayout(notepadWindow.WindowID, "floating").
+				SetLayoutWithOpts(
+					windows.SetLayoutArgs{
+						Layouts: []string{"floating"},
+					},
+					windows.SetLayoutOpts{
+						WindowID: &notepadWindow.WindowID,
+					},
+				).
 				Return(nil).
 				Times(0), // DO NOT RUN
 		)
@@ -536,19 +580,49 @@ func TestMoveCmd(t *testing.T) {
 
 			// For each window, expect a pair of calls (MoveWindowToWorkspace followed by SetLayout)
 			// Window 1 (5678)
+			windowID1 := 5678
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(5678, constants.DefaultScratchpadWorkspaceName).
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: constants.DefaultScratchpadWorkspaceName,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &windowID1,
+					},
+				).
 				Return(nil)
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayout(5678, "floating").
+				SetLayoutWithOpts(
+					windows.SetLayoutArgs{
+						Layouts: []string{"floating"},
+					},
+					windows.SetLayoutOpts{
+						WindowID: &windowID1,
+					},
+				).
 				Return(nil)
 
 			// Window 2 (1111)
+			windowID2 := 1111
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(1111, constants.DefaultScratchpadWorkspaceName).
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: constants.DefaultScratchpadWorkspaceName,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &windowID2,
+					},
+				).
 				Return(nil)
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayout(1111, "floating").
+				SetLayoutWithOpts(
+					windows.SetLayoutArgs{
+						Layouts: []string{"floating"},
+					},
+					windows.SetLayoutOpts{
+						WindowID: &windowID2,
+					},
+				).
 				Return(nil)
 
 			wrappedClient := aerospace.NewAeroSpaceClient(aerospaceClient)
@@ -616,12 +690,12 @@ func TestMoveCmd(t *testing.T) {
 
 				// DO NOT RUN in dry-run mode
 				aerospaceClient.GetWorkspacesMock().EXPECT().
-					MoveWindowToWorkspace(gomock.Any(), gomock.Any()).
+					MoveWindowToWorkspaceWithOpts(gomock.Any(), gomock.Any()).
 					Return(nil).
 					Times(0),
 
 				aerospaceClient.GetWindowsMock().EXPECT().
-					SetLayout(gomock.Any(), gomock.Any()).
+					SetLayoutWithOpts(gomock.Any(), gomock.Any()).
 					Return(nil).
 					Times(0),
 			)

--- a/cmd/next_test.go
+++ b/cmd/next_test.go
@@ -65,6 +65,7 @@ func TestNextCmd(t *testing.T) {
 		scratchpadWindows := testutils.ExtractScratchpadWindows(tree)
 
 		aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
+		windowID := 9999
 		gomock.InOrder(
 			aerospaceClient.GetWorkspacesMock().EXPECT().
 				GetFocusedWorkspace().
@@ -75,14 +76,20 @@ func TestNextCmd(t *testing.T) {
 				Return(scratchpadWindows.Windows, nil).
 				Times(1),
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(
-					9999, // The ID of the first scratchpad window
-					focusedTree.Workspace.Workspace,
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: focusedTree.Workspace.Workspace,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &windowID,
+					},
 				).
 				Return(nil).
 				Times(1),
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(9999). // Focus the moved window
+				SetFocusByWindowID(windows.SetFocusArgs{
+					WindowID: 9999,
+				}). // Focus the moved window
 				Return(nil).
 				Times(1),
 		)

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -175,13 +175,15 @@ func TestShowCmd(t *testing.T) {
 					Times(1),
 
 				aerospaceClient.GetWindowsMock().EXPECT().
-					SetFocusByWindowID(focusedTree.Windows[1].WindowID).
+					SetFocusByWindowID(windows.SetFocusArgs{
+						WindowID: focusedTree.Windows[1].WindowID,
+					}).
 					Return(nil).
 					Times(1),
 
 				// DO NOT set the layout to floating
 				aerospaceClient.GetWindowsMock().EXPECT().
-					SetLayout(gomock.Any(), "floating").
+					SetLayoutWithOpts(gomock.Any(), gomock.Any()).
 					Return(nil).
 					Times(0),
 			)
@@ -270,20 +272,34 @@ func TestShowCmd(t *testing.T) {
 			// Connection() is handled by routing connection, no need to mock
 
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(
-					focusedWindow.WindowID,
-					constants.DefaultScratchpadWorkspaceName).
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: constants.DefaultScratchpadWorkspaceName,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &focusedWindow.WindowID,
+					},
+				).
 				Return(nil).
 				Times(1),
 
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(focusedWindow.WindowID).
+				SetFocusByWindowID(windows.SetFocusArgs{
+					WindowID: focusedWindow.WindowID,
+				}).
 				Return(nil).
 				Times(0),
 
 			// When moving to scratchpad, set the layout to floating
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayout(focusedWindow.WindowID, "floating").
+				SetLayoutWithOpts(
+					windows.SetLayoutArgs{
+						Layouts: []string{"floating"},
+					},
+					windows.SetLayoutOpts{
+						WindowID: &focusedWindow.WindowID,
+					},
+				).
 				Return(nil).
 				Times(1),
 		)
@@ -367,21 +383,34 @@ func TestShowCmd(t *testing.T) {
 					Times(1),
 
 				aerospaceClient.GetWorkspacesMock().EXPECT().
-					MoveWindowToWorkspace(
-						tree[0].Windows[1].WindowID,
-						focusedTree.Workspace.Workspace).
+					MoveWindowToWorkspaceWithOpts(
+						workspaces.MoveWindowToWorkspaceArgs{
+							WorkspaceName: focusedTree.Workspace.Workspace,
+						},
+						workspaces.MoveWindowToWorkspaceOpts{
+							WindowID: &tree[0].Windows[1].WindowID,
+						},
+					).
 					Return(nil).
 					Times(1),
 
 				aerospaceClient.GetWindowsMock().EXPECT().
-					SetFocusByWindowID(
-						tree[0].Windows[1].WindowID).
+					SetFocusByWindowID(windows.SetFocusArgs{
+						WindowID: tree[0].Windows[1].WindowID,
+					}).
 					Return(nil).
 					Times(1),
 
 				// When moving to scratchpad, set the layout to floating
 				aerospaceClient.GetWindowsMock().EXPECT().
-					SetLayout(focusedWindow.WindowID, "floating").
+					SetLayoutWithOpts(
+						windows.SetLayoutArgs{
+							Layouts: []string{"floating"},
+						},
+						windows.SetLayoutOpts{
+							WindowID: &focusedWindow.WindowID,
+						},
+					).
 					Return(nil).
 					Times(0),
 			)
@@ -475,31 +504,39 @@ func TestShowCmd(t *testing.T) {
 			gomock.InOrder(
 				// Send first window
 				aerospaceClient.GetWorkspacesMock().EXPECT().
-					MoveWindowToWorkspace(
-						tree[0].Windows[0].WindowID,
-						focusedTree.Workspace.Workspace,
+					MoveWindowToWorkspaceWithOpts(
+						workspaces.MoveWindowToWorkspaceArgs{
+							WorkspaceName: focusedTree.Workspace.Workspace,
+						},
+						workspaces.MoveWindowToWorkspaceOpts{
+							WindowID: &tree[0].Windows[0].WindowID,
+						},
 					).
 					Return(nil).
 					Times(1),
 				aerospaceClient.GetWindowsMock().EXPECT().
-					SetFocusByWindowID(
-						tree[0].Windows[0].WindowID,
-					).
+					SetFocusByWindowID(windows.SetFocusArgs{
+						WindowID: tree[0].Windows[0].WindowID,
+					}).
 					Return(nil).
 					Times(1),
 
 				// Send 2nd window
 				aerospaceClient.GetWorkspacesMock().EXPECT().
-					MoveWindowToWorkspace(
-						tree[0].Windows[1].WindowID,
-						focusedTree.Workspace.Workspace,
+					MoveWindowToWorkspaceWithOpts(
+						workspaces.MoveWindowToWorkspaceArgs{
+							WorkspaceName: focusedTree.Workspace.Workspace,
+						},
+						workspaces.MoveWindowToWorkspaceOpts{
+							WindowID: &tree[0].Windows[1].WindowID,
+						},
 					).
 					Return(nil).
 					Times(1),
 				aerospaceClient.GetWindowsMock().EXPECT().
-					SetFocusByWindowID(
-						tree[0].Windows[1].WindowID,
-					).
+					SetFocusByWindowID(windows.SetFocusArgs{
+						WindowID: tree[0].Windows[1].WindowID,
+					}).
 					Return(nil).
 					Times(1),
 			)
@@ -597,32 +634,48 @@ func TestShowCmd(t *testing.T) {
 					// First window operations
 					// Connection() is handled by routing connection, no need to mock
 					aerospaceClient.GetWorkspacesMock().EXPECT().
-						MoveWindowToWorkspace(
-							tree[1].Windows[0].WindowID,
-							constants.DefaultScratchpadWorkspaceName,
+						MoveWindowToWorkspaceWithOpts(
+							workspaces.MoveWindowToWorkspaceArgs{
+								WorkspaceName: constants.DefaultScratchpadWorkspaceName,
+							},
+							workspaces.MoveWindowToWorkspaceOpts{
+								WindowID: &tree[1].Windows[0].WindowID,
+							},
 						).
 						Return(nil).
 						Times(1),
 					aerospaceClient.GetWindowsMock().EXPECT().
-						SetLayout(
-							tree[1].Windows[0].WindowID,
-							"floating",
+						SetLayoutWithOpts(
+							windows.SetLayoutArgs{
+								Layouts: []string{"floating"},
+							},
+							windows.SetLayoutOpts{
+								WindowID: &tree[1].Windows[0].WindowID,
+							},
 						).
 						Return(nil).
 						Times(1),
 
 					// Second window operations
 					aerospaceClient.GetWorkspacesMock().EXPECT().
-						MoveWindowToWorkspace(
-							tree[1].Windows[1].WindowID,
-							constants.DefaultScratchpadWorkspaceName,
+						MoveWindowToWorkspaceWithOpts(
+							workspaces.MoveWindowToWorkspaceArgs{
+								WorkspaceName: constants.DefaultScratchpadWorkspaceName,
+							},
+							workspaces.MoveWindowToWorkspaceOpts{
+								WindowID: &tree[1].Windows[1].WindowID,
+							},
 						).
 						Return(nil).
 						Times(1),
 					aerospaceClient.GetWindowsMock().EXPECT().
-						SetLayout(
-							tree[1].Windows[1].WindowID,
-							"floating",
+						SetLayoutWithOpts(
+							windows.SetLayoutArgs{
+								Layouts: []string{"floating"},
+							},
+							windows.SetLayoutOpts{
+								WindowID: &tree[1].Windows[1].WindowID,
+							},
 						).
 						Return(nil).
 						Times(1),
@@ -726,24 +779,28 @@ func TestShowCmd(t *testing.T) {
 						Times(1),
 
 					aerospaceClient.GetWorkspacesMock().EXPECT().
-						MoveWindowToWorkspace(
-							tree[0].Windows[0].WindowID,
-							focusedTree.Workspace.Workspace,
+						MoveWindowToWorkspaceWithOpts(
+							workspaces.MoveWindowToWorkspaceArgs{
+								WorkspaceName: focusedTree.Workspace.Workspace,
+							},
+							workspaces.MoveWindowToWorkspaceOpts{
+								WindowID: &tree[0].Windows[0].WindowID,
+							},
 						).
 						Return(nil).
 						Times(1),
 
 					aerospaceClient.GetWindowsMock().EXPECT().
-						SetFocusByWindowID(
-							tree[0].Windows[0].WindowID,
-						).
+						SetFocusByWindowID(windows.SetFocusArgs{
+							WindowID: tree[0].Windows[0].WindowID,
+						}).
 						Return(nil).
 						Times(1),
 
 					aerospaceClient.GetWindowsMock().EXPECT().
-						SetFocusByWindowID(
-							tree[1].Windows[0].WindowID,
-						).
+						SetFocusByWindowID(windows.SetFocusArgs{
+							WindowID: tree[1].Windows[0].WindowID,
+						}).
 						Return(nil).
 						Times(1),
 				)
@@ -846,17 +903,21 @@ func TestShowCmd(t *testing.T) {
 						Times(1),
 
 					aerospaceClient.GetWorkspacesMock().EXPECT().
-						MoveWindowToWorkspace(
-							tree[0].Windows[0].WindowID,
-							focusedTree.Workspace.Workspace,
+						MoveWindowToWorkspaceWithOpts(
+							workspaces.MoveWindowToWorkspaceArgs{
+								WorkspaceName: focusedTree.Workspace.Workspace,
+							},
+							workspaces.MoveWindowToWorkspaceOpts{
+								WindowID: &tree[0].Windows[0].WindowID,
+							},
 						).
 						Return(nil).
 						Times(1),
 
 					aerospaceClient.GetWindowsMock().EXPECT().
-						SetFocusByWindowID(
-							tree[1].Windows[0].WindowID,
-						).
+						SetFocusByWindowID(windows.SetFocusArgs{
+							WindowID: tree[1].Windows[0].WindowID,
+						}).
 						Return(nil).
 						Times(1),
 				)
@@ -956,16 +1017,20 @@ func TestShowCmd(t *testing.T) {
 				gomock.InOrder(
 					// Send first window
 					aerospaceClient.GetWorkspacesMock().EXPECT().
-						MoveWindowToWorkspace(
-							tree[0].Windows[0].WindowID,
-							focusedTree.Workspace.Workspace,
+						MoveWindowToWorkspaceWithOpts(
+							workspaces.MoveWindowToWorkspaceArgs{
+								WorkspaceName: focusedTree.Workspace.Workspace,
+							},
+							workspaces.MoveWindowToWorkspaceOpts{
+								WindowID: &tree[0].Windows[0].WindowID,
+							},
 						).
 						Return(nil).
 						Times(1),
 					aerospaceClient.GetWindowsMock().EXPECT().
-						SetFocusByWindowID(
-							tree[0].Windows[0].WindowID,
-						).
+						SetFocusByWindowID(windows.SetFocusArgs{
+							WindowID: tree[0].Windows[0].WindowID,
+						}).
 						Return(nil).
 						Times(1),
 				)
@@ -1074,16 +1139,20 @@ func TestShowCmd(t *testing.T) {
 				gomock.InOrder(
 					// Send first window
 					aerospaceClient.GetWorkspacesMock().EXPECT().
-						MoveWindowToWorkspace(
-							tree[0].Windows[0].WindowID,
-							focusedTree.Workspace.Workspace,
+						MoveWindowToWorkspaceWithOpts(
+							workspaces.MoveWindowToWorkspaceArgs{
+								WorkspaceName: focusedTree.Workspace.Workspace,
+							},
+							workspaces.MoveWindowToWorkspaceOpts{
+								WindowID: &tree[0].Windows[0].WindowID,
+							},
 						).
 						Return(nil).
 						Times(1),
 					aerospaceClient.GetWindowsMock().EXPECT().
-						SetFocusByWindowID(
-							tree[0].Windows[0].WindowID,
-						).
+						SetFocusByWindowID(windows.SetFocusArgs{
+							WindowID: tree[0].Windows[0].WindowID,
+						}).
 						Return(nil).
 						Times(1),
 				)

--- a/cmd/summon_test.go
+++ b/cmd/summon_test.go
@@ -50,11 +50,11 @@ func TestSummonCmd(t *testing.T) {
 		}
 		allWindows := testutils.ExtractAllWindows(tree)
 		focusedWorkspace := &workspaces.Workspace{Workspace: "ws1"}
-		windows := testutils.ExtractWindowsByName(tree, "Notepad")
-		if len(windows) != 1 {
-			t.Fatalf("Expected 1 Notepad window, got %d", len(windows))
+		matchedWindows := testutils.ExtractWindowsByName(tree, "Notepad")
+		if len(matchedWindows) != 1 {
+			t.Fatalf("Expected 1 Notepad window, got %d", len(matchedWindows))
 		}
-		notepadWindow := windows[0]
+		notepadWindow := matchedWindows[0]
 
 		aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
 		gomock.InOrder(
@@ -70,12 +70,21 @@ func TestSummonCmd(t *testing.T) {
 				Times(1),
 
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(notepadWindow.WindowID, focusedWorkspace.Workspace).
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: focusedWorkspace.Workspace,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &notepadWindow.WindowID,
+					},
+				).
 				Return(nil).
 				Times(1),
 
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(notepadWindow.WindowID).
+				SetFocusByWindowID(windows.SetFocusArgs{
+					WindowID: notepadWindow.WindowID,
+				}).
 				Return(nil).
 				Times(1),
 		)
@@ -319,7 +328,14 @@ func TestSummonCmd(t *testing.T) {
 					Times(1),
 
 				aerospaceClient.GetWorkspacesMock().EXPECT().
-					MoveWindowToWorkspace(notepadWindow.WindowID, focusedWorkspace.Workspace).
+					MoveWindowToWorkspaceWithOpts(
+						workspaces.MoveWindowToWorkspaceArgs{
+							WorkspaceName: focusedWorkspace.Workspace,
+						},
+						workspaces.MoveWindowToWorkspaceOpts{
+							WindowID: &notepadWindow.WindowID,
+						},
+					).
 					Return(errors.New("mocked_move_error")).
 					Times(1),
 			)
@@ -368,11 +384,11 @@ func TestSummonCmd(t *testing.T) {
 		}
 		allWindows := testutils.ExtractAllWindows(tree)
 		focusedWorkspace := &workspaces.Workspace{Workspace: "ws1"}
-		windows := testutils.ExtractWindowsByName(tree, "Notepad")
-		if len(windows) != 1 {
-			t.Fatalf("Expected 1 Notepad window, got %d", len(windows))
+		matchedWindows := testutils.ExtractWindowsByName(tree, "Notepad")
+		if len(matchedWindows) != 1 {
+			t.Fatalf("Expected 1 Notepad window, got %d", len(matchedWindows))
 		}
-		notepadWindow := windows[0]
+		notepadWindow := matchedWindows[0]
 
 		aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
 		gomock.InOrder(
@@ -387,12 +403,21 @@ func TestSummonCmd(t *testing.T) {
 				Times(1),
 
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(notepadWindow.WindowID, focusedWorkspace.Workspace).
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: focusedWorkspace.Workspace,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &notepadWindow.WindowID,
+					},
+				).
 				Return(nil).
 				Times(1),
 
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(notepadWindow.WindowID).
+				SetFocusByWindowID(windows.SetFocusArgs{
+					WindowID: notepadWindow.WindowID,
+				}).
 				Return(errors.New("mocked_focus_error")).
 				Times(1),
 		)
@@ -445,14 +470,14 @@ func TestSummonCmd(t *testing.T) {
 		}
 		allWindows := testutils.ExtractAllWindows(tree)
 		focusedWorkspace := &workspaces.Workspace{Workspace: "ws1"}
-		windows := testutils.ExtractWindowsByName(
+		matchedWindows := testutils.ExtractWindowsByName(
 			tree,
 			".*(Notepad|TextEdit).*",
 		)
-		if len(windows) != 2 {
+		if len(matchedWindows) != 2 {
 			t.Fatalf(
 				"Expected 2 windows matching pattern, got %d",
-				len(windows),
+				len(matchedWindows),
 			)
 		}
 
@@ -469,22 +494,40 @@ func TestSummonCmd(t *testing.T) {
 				Times(1),
 
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(windows[0].WindowID, focusedWorkspace.Workspace).
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: focusedWorkspace.Workspace,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &matchedWindows[0].WindowID,
+					},
+				).
 				Return(nil).
 				Times(1),
 
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(windows[0].WindowID).
+				SetFocusByWindowID(windows.SetFocusArgs{
+					WindowID: matchedWindows[0].WindowID,
+				}).
 				Return(nil).
 				Times(1),
 
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(windows[1].WindowID, focusedWorkspace.Workspace).
+				MoveWindowToWorkspaceWithOpts(
+					workspaces.MoveWindowToWorkspaceArgs{
+						WorkspaceName: focusedWorkspace.Workspace,
+					},
+					workspaces.MoveWindowToWorkspaceOpts{
+						WindowID: &matchedWindows[1].WindowID,
+					},
+				).
 				Return(nil).
 				Times(1),
 
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(windows[1].WindowID).
+				SetFocusByWindowID(windows.SetFocusArgs{
+					WindowID: matchedWindows[1].WindowID,
+				}).
 				Return(nil).
 				Times(1),
 		)
@@ -573,11 +616,6 @@ func TestSummonCmd(t *testing.T) {
 		}
 		allWindows := testutils.ExtractAllWindows(tree)
 		focusedWorkspace := &workspaces.Workspace{Workspace: "ws1"}
-		windows := testutils.ExtractWindowsByName(tree, "Notepad")
-		if len(windows) != 1 {
-			t.Fatalf("Expected 1 Notepad window, got %d", len(windows))
-		}
-		notepadWindow := windows[0]
 
 		aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
 		gomock.InOrder(
@@ -594,12 +632,12 @@ func TestSummonCmd(t *testing.T) {
 			// In dry-run mode, the aerospace client wrapper intercepts these calls
 			// and prints debug messages instead of calling the actual methods
 			aerospaceClient.GetWorkspacesMock().EXPECT().
-				MoveWindowToWorkspace(notepadWindow.WindowID, focusedWorkspace.Workspace).
+				MoveWindowToWorkspaceWithOpts(gomock.Any(), gomock.Any()).
 				Return(nil).
 				Times(0), // DO NOT RUN in dry-run mode
 
 			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(notepadWindow.WindowID).
+				SetFocusByWindowID(gomock.Any()).
 				Return(nil).
 				Times(0), // DO NOT RUN in dry-run mode
 		)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cristianoliveira/aerospace-scratchpad
 go 1.24.2
 
 require (
-	github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251129205702-c6ef7f778136
+	github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251130115621-503d03b8be64
 	github.com/gkampitakis/go-snaps v0.5.11
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/mock v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251129205702-c6ef7f778136 h1:3TuxTHt+hS5uNLhKUxBkfP6Lee1MUYOx/gbvq9h/Vdw=
 github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251129205702-c6ef7f778136/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
+github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251130115621-503d03b8be64 h1:pOOBFRnKrWwDr2n2eJ7eQv8X5ouWePdrD8b1CaF41N4=
+github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251130115621-503d03b8be64/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
 github.com/gkampitakis/ciinfo v0.3.1 h1:lzjbemlGI4Q+XimPg64ss89x8Mf3xihJqy/0Mgagapo=
 github.com/gkampitakis/ciinfo v0.3.1/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=

--- a/internal/aerospace/mover.go
+++ b/internal/aerospace/mover.go
@@ -47,9 +47,14 @@ func (a *MoverAeroSpace) MoveWindowToScratchpad(
 			constants.DefaultScratchpadWorkspaceName,
 		)
 	} else {
-		err = a.aerospace.Workspaces().MoveWindowToWorkspace(
-			window.WindowID,
-			constants.DefaultScratchpadWorkspaceName,
+		windowID := window.WindowID
+		err = a.aerospace.Workspaces().MoveWindowToWorkspaceWithOpts(
+			workspaces.MoveWindowToWorkspaceArgs{
+				WorkspaceName: constants.DefaultScratchpadWorkspaceName,
+			},
+			workspaces.MoveWindowToWorkspaceOpts{
+				WindowID: &windowID,
+			},
 		)
 	}
 	logger.LogDebug(
@@ -66,7 +71,15 @@ func (a *MoverAeroSpace) MoveWindowToScratchpad(
 	if wrapper, ok := a.aerospace.(*AeroSpaceClient); ok {
 		err = wrapper.SetLayout(window.WindowID, "floating")
 	} else {
-		err = a.aerospace.Windows().SetLayout(window.WindowID, "floating")
+		windowID := window.WindowID
+		err = a.aerospace.Windows().SetLayoutWithOpts(
+			windows.SetLayoutArgs{
+				Layouts: []string{"floating"},
+			},
+			windows.SetLayoutOpts{
+				WindowID: &windowID,
+			},
+		)
 	}
 	if err != nil {
 		fmt.Fprintf(
@@ -108,9 +121,14 @@ func (a *MoverAeroSpace) MoveWindowToWorkspace(
 		}
 	} else {
 		// Fallback to direct service call
-		if err := a.aerospace.Workspaces().MoveWindowToWorkspace(
-			window.WindowID,
-			workspace.Workspace,
+		windowID := window.WindowID
+		if err := a.aerospace.Workspaces().MoveWindowToWorkspaceWithOpts(
+			workspaces.MoveWindowToWorkspaceArgs{
+				WorkspaceName: workspace.Workspace,
+			},
+			workspaces.MoveWindowToWorkspaceOpts{
+				WindowID: &windowID,
+			},
 		); err != nil {
 			return fmt.Errorf(
 				"unable to move window '%+v' to workspace '%s': %w",
@@ -142,7 +160,9 @@ func (a *MoverAeroSpace) MoveWindowToWorkspace(
 		}
 	} else {
 		// Fallback to direct service call
-		if err := a.aerospace.Windows().SetFocusByWindowID(window.WindowID); err != nil {
+		if err := a.aerospace.Windows().SetFocusByWindowID(windows.SetFocusArgs{
+			WindowID: window.WindowID,
+		}); err != nil {
 			return fmt.Errorf(
 				"unable to set focus to window '%+v': %w",
 				window,


### PR DESCRIPTION
Summary:
This commit refactors test cases to replace `SetFocusByWindowID` with `SetFocus` and ensures passing window IDs as pointers.

Detailed Changes:
 - cmd/next_test.go:
   - Updated function calls to use `SetFocus` with pointer arguments.

 - cmd/show_test.go:
   - Changed method calls from `SetFocusByWindowID` to `SetFocus`.
   - Modified how window IDs are passed to follow pointer convention.
 - cmd/summon_test.go:
   - Replaced usage of `SetFocusByWindowID` with `SetFocus`, adjusting window ID passing as pointers.
 - go.mod, go.sum:
   - Updated the version of `github.com/cristianoliveira/aerospace-ipc`.
 - internal/aerospace/client.go:
   - Altered `SetFocusByWindowID` usage to `SetFocus`, incorporating pointer-based window ID passing.
   - Refactored `FocusNextTilingWindow` to accommodate new method signatures and error handling.
 - internal/aerospace/mover.go:
   - Modified window focus logic to use pointer-based `SetFocus` method.
 - internal/testutils/mock_client.go:
   - Adjusted mock client to reflect changes from `SetFocusByWindowID` to `SetFocus` with pointer usage.