### PR TITLE
refactor: update ipc client and tests

### DIFF
--- a/cmd/__snapshots__/move_test.snap
+++ b/cmd/__snapshots__/move_test.snap
@@ -3,8 +3,8 @@
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
@@ -23,8 +23,8 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
@@ -54,8 +54,8 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
@@ -75,8 +75,8 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
@@ -95,8 +95,8 @@ Error: Window '5678 | Finder ' already belongs to scratchpad
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
@@ -119,8 +119,8 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1111, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1111, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
@@ -140,8 +140,8 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1111, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1111, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
@@ -168,8 +168,8 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1111, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1111, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,

--- a/cmd/__snapshots__/next_test.snap
+++ b/cmd/__snapshots__/next_test.snap
@@ -3,16 +3,16 @@
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
     },
     {
         Windows: {
-            {WindowID:9999, WindowTitle:"", AppName:"Scratchpad Window", AppBundleID:"", Workspace:""},
-            {WindowID:8888, WindowTitle:"", AppName:"Another Scratchpad Window", AppBundleID:"", Workspace:""},
+            {WindowID:9999, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Scratchpad Window", AppBundleID:"", Workspace:""},
+            {WindowID:8888, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Another Scratchpad Window", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:".scratchpad"},
         FocusedWindowID: 0,

--- a/cmd/__snapshots__/show_test.snap
+++ b/cmd/__snapshots__/show_test.snap
@@ -3,8 +3,8 @@
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
@@ -23,8 +23,8 @@ Error: <pattern> cannot be empty
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 1234,
@@ -43,8 +43,8 @@ Error: no windows matched the pattern 'foo'
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 1234,
@@ -63,8 +63,8 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
@@ -83,15 +83,15 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 0,
     },
     {
         Windows: {
-            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:""},
+            {WindowID:91011, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Terminal", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws2"},
         FocusedWindowID: 91011,
@@ -110,15 +110,15 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:5678, WindowTitle:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
-            {WindowID:5679, WindowTitle:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:5679, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws1"},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 0,
     },
     {
         Windows: {
-            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:91011, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws2"},
         FocusedWindowID: 91011,
@@ -144,9 +144,9 @@ Error
     },
     {
         Windows: {
-            {WindowID:5678, WindowTitle:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws2"},
-            {WindowID:5679, WindowTitle:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws2"},
-            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:5679, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:91011, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws2"},
         FocusedWindowID: 5678,
@@ -166,16 +166,16 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:5678, WindowTitle:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
-            {WindowID:22, WindowTitle:"", AppName:"Browser", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:22, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Browser", AppBundleID:"", Workspace:"ws1"},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 0,
     },
     {
         Windows: {
-            {WindowID:5679, WindowTitle:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws2"},
-            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:5679, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:91011, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws2"},
         FocusedWindowID: 91011,
@@ -195,16 +195,16 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:5678, WindowTitle:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
-            {WindowID:22, WindowTitle:"", AppName:"Browser", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:22, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Browser", AppBundleID:"", Workspace:"ws1"},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 0,
     },
     {
         Windows: {
-            {WindowID:5679, WindowTitle:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws2"},
-            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:5679, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:91011, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws2"},
         FocusedWindowID: 5679,
@@ -224,15 +224,15 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:5678, WindowTitle:"Finder - foo and zas", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
-            {WindowID:5679, WindowTitle:"", AppName:"Finder2 - bar and baz", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:5678, WindowTitle:"Finder - foo and zas", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:5679, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder2 - bar and baz", AppBundleID:"", Workspace:"ws1"},
         },
         Workspace:       &workspaces.Workspace{Workspace:".scratchpad"},
         FocusedWindowID: 0,
     },
     {
         Windows: {
-            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:91011, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws2"},
         FocusedWindowID: 91011,
@@ -307,16 +307,16 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:5678, WindowTitle:"Finder - foo and zas", AppName:"Finder1", AppBundleID:"com.linux.finder", Workspace:"ws1"},
-            {WindowID:5679, WindowTitle:"Finder2 - foo and baz", AppName:"Finder2", AppBundleID:"com.apple.finder", Workspace:"ws1"},
-            {WindowID:5680, WindowTitle:"Finder2 - bar and baz", AppName:"Finder2", AppBundleID:"com.apple.finder", Workspace:"ws1"},
+            {WindowID:5678, WindowTitle:"Finder - foo and zas", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder1", AppBundleID:"com.linux.finder", Workspace:"ws1"},
+            {WindowID:5679, WindowTitle:"Finder2 - foo and baz", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder2", AppBundleID:"com.apple.finder", Workspace:"ws1"},
+            {WindowID:5680, WindowTitle:"Finder2 - bar and baz", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder2", AppBundleID:"com.apple.finder", Workspace:"ws1"},
         },
         Workspace:       &workspaces.Workspace{Workspace:".scratchpad"},
         FocusedWindowID: 0,
     },
     {
         Windows: {
-            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:91011, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws2"},
         FocusedWindowID: 91011,
@@ -335,8 +335,8 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:5678, WindowTitle:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
-            {WindowID:5670, WindowTitle:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:5670, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder2", AppBundleID:"", Workspace:"ws1"},
         },
         Workspace:       &workspaces.Workspace{Workspace:".scratchpad"},
         FocusedWindowID: 5670,
@@ -355,15 +355,15 @@ Error: error applying filters to window 'Finder1': unknown filter property: unkn
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:5678, WindowTitle:"Finder - foo and zas", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
-            {WindowID:5679, WindowTitle:"", AppName:"Finder2 - bar and baz", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:5678, WindowTitle:"Finder - foo and zas", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder1", AppBundleID:"", Workspace:"ws1"},
+            {WindowID:5679, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder2 - bar and baz", AppBundleID:"", Workspace:"ws1"},
         },
         Workspace:       &workspaces.Workspace{Workspace:".scratchpad"},
         FocusedWindowID: 0,
     },
     {
         Windows: {
-            {WindowID:91011, WindowTitle:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
+            {WindowID:91011, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Terminal", AppBundleID:"", Workspace:"ws2"},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws2"},
         FocusedWindowID: 91011,

--- a/cmd/__snapshots__/summon_test.snap
+++ b/cmd/__snapshots__/summon_test.snap
@@ -3,8 +3,8 @@
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
@@ -23,8 +23,8 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,
@@ -93,9 +93,9 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"TextEdit", AppBundleID:"", Workspace:""},
-            {WindowID:9012, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"TextEdit", AppBundleID:"", Workspace:""},
+            {WindowID:9012, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 9012,
@@ -133,8 +133,8 @@ Error
 []testutils.AeroSpaceTree{
     {
         Windows: {
-            {WindowID:1234, WindowTitle:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
-            {WindowID:5678, WindowTitle:"", AppName:"Finder", AppBundleID:"", Workspace:""},
+            {WindowID:1234, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Notepad", AppBundleID:"", Workspace:""},
+            {WindowID:5678, WindowTitle:"", WindowLayout:"", WindowParentContainerLayout:"", AppName:"Finder", AppBundleID:"", Workspace:""},
         },
         Workspace:       &workspaces.Workspace{Workspace:"ws1"},
         FocusedWindowID: 5678,

--- a/cmd/move_test.go
+++ b/cmd/move_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"go.uber.org/mock/gomock"
 
+	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/layout"
 	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/windows"
 	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/workspaces"
 	"github.com/cristianoliveira/aerospace-scratchpad/cmd"
@@ -138,12 +139,10 @@ func TestMoveCmd(t *testing.T) {
 				Return(nil).
 				Times(1),
 
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayoutWithOpts(
-					windows.SetLayoutArgs{
-						Layouts: []string{"floating"},
-					},
-					windows.SetLayoutOpts{
+			aerospaceClient.GetLayoutMock().EXPECT().
+				SetLayout(
+					[]string{"floating"},
+					layout.SetLayoutOpts{
 						WindowID: &focusedWindow.WindowID,
 					},
 				).
@@ -223,12 +222,10 @@ func TestMoveCmd(t *testing.T) {
 				Return(nil).
 				Times(1),
 
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayoutWithOpts(
-					windows.SetLayoutArgs{
-						Layouts: []string{"floating"},
-					},
-					windows.SetLayoutOpts{
+			aerospaceClient.GetLayoutMock().EXPECT().
+				SetLayout(
+					[]string{"floating"},
+					layout.SetLayoutOpts{
 						WindowID: &focusedWindow.WindowID,
 					},
 				).
@@ -350,12 +347,10 @@ func TestMoveCmd(t *testing.T) {
 				Return(nil).
 				Times(1),
 
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayoutWithOpts(
-					windows.SetLayoutArgs{
-						Layouts: []string{"floating"},
-					},
-					windows.SetLayoutOpts{
+			aerospaceClient.GetLayoutMock().EXPECT().
+				SetLayout(
+					[]string{"floating"},
+					layout.SetLayoutOpts{
 						WindowID: &notepadWindow.WindowID,
 					},
 				).
@@ -431,8 +426,8 @@ func TestMoveCmd(t *testing.T) {
 				).
 				Times(1),
 
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayoutWithOpts(gomock.Any(), gomock.Any()).
+			aerospaceClient.GetLayoutMock().EXPECT().
+				SetLayout(gomock.Any(), gomock.Any()).
 				Return(nil).
 				Times(0),
 		)
@@ -591,12 +586,10 @@ func TestMoveCmd(t *testing.T) {
 					},
 				).
 				Return(nil)
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayoutWithOpts(
-					windows.SetLayoutArgs{
-						Layouts: []string{"floating"},
-					},
-					windows.SetLayoutOpts{
+			aerospaceClient.GetLayoutMock().EXPECT().
+				SetLayout(
+					[]string{"floating"},
+					layout.SetLayoutOpts{
 						WindowID: &windowID1,
 					},
 				).
@@ -614,12 +607,10 @@ func TestMoveCmd(t *testing.T) {
 					},
 				).
 				Return(nil)
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayoutWithOpts(
-					windows.SetLayoutArgs{
-						Layouts: []string{"floating"},
-					},
-					windows.SetLayoutOpts{
+			aerospaceClient.GetLayoutMock().EXPECT().
+				SetLayout(
+					[]string{"floating"},
+					layout.SetLayoutOpts{
 						WindowID: &windowID2,
 					},
 				).
@@ -694,8 +685,8 @@ func TestMoveCmd(t *testing.T) {
 					Return(nil).
 					Times(0),
 
-				aerospaceClient.GetWindowsMock().EXPECT().
-					SetLayoutWithOpts(gomock.Any(), gomock.Any()).
+				aerospaceClient.GetLayoutMock().EXPECT().
+					SetLayout(gomock.Any(), gomock.Any()).
 					Return(nil).
 					Times(0),
 			)

--- a/cmd/next_test.go
+++ b/cmd/next_test.go
@@ -86,10 +86,8 @@ func TestNextCmd(t *testing.T) {
 				).
 				Return(nil).
 				Times(1),
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(windows.SetFocusArgs{
-					WindowID: 9999,
-				}). // Focus the moved window
+			aerospaceClient.GetFocusMock().EXPECT().
+				SetFocusByWindowID(9999). // Focus the moved window
 				Return(nil).
 				Times(1),
 		)

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"go.uber.org/mock/gomock"
 
+	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/layout"
 	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/windows"
 	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/workspaces"
 	"github.com/cristianoliveira/aerospace-scratchpad/cmd"
@@ -174,16 +175,14 @@ func TestShowCmd(t *testing.T) {
 					Return(focusedWindow, nil).
 					Times(1),
 
-				aerospaceClient.GetWindowsMock().EXPECT().
-					SetFocusByWindowID(windows.SetFocusArgs{
-						WindowID: focusedTree.Windows[1].WindowID,
-					}).
+				aerospaceClient.GetFocusMock().EXPECT().
+					SetFocusByWindowID(focusedTree.Windows[1].WindowID).
 					Return(nil).
 					Times(1),
 
 				// DO NOT set the layout to floating
-				aerospaceClient.GetWindowsMock().EXPECT().
-					SetLayoutWithOpts(gomock.Any(), gomock.Any()).
+				aerospaceClient.GetLayoutMock().EXPECT().
+					SetLayout(gomock.Any(), gomock.Any()).
 					Return(nil).
 					Times(0),
 			)
@@ -283,20 +282,16 @@ func TestShowCmd(t *testing.T) {
 				Return(nil).
 				Times(1),
 
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(windows.SetFocusArgs{
-					WindowID: focusedWindow.WindowID,
-				}).
+			aerospaceClient.GetFocusMock().EXPECT().
+				SetFocusByWindowID(focusedWindow.WindowID).
 				Return(nil).
 				Times(0),
 
 			// When moving to scratchpad, set the layout to floating
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetLayoutWithOpts(
-					windows.SetLayoutArgs{
-						Layouts: []string{"floating"},
-					},
-					windows.SetLayoutOpts{
+			aerospaceClient.GetLayoutMock().EXPECT().
+				SetLayout(
+					[]string{"floating"},
+					layout.SetLayoutOpts{
 						WindowID: &focusedWindow.WindowID,
 					},
 				).
@@ -394,20 +389,16 @@ func TestShowCmd(t *testing.T) {
 					Return(nil).
 					Times(1),
 
-				aerospaceClient.GetWindowsMock().EXPECT().
-					SetFocusByWindowID(windows.SetFocusArgs{
-						WindowID: tree[0].Windows[1].WindowID,
-					}).
+				aerospaceClient.GetFocusMock().EXPECT().
+					SetFocusByWindowID(tree[0].Windows[1].WindowID).
 					Return(nil).
 					Times(1),
 
 				// When moving to scratchpad, set the layout to floating
-				aerospaceClient.GetWindowsMock().EXPECT().
-					SetLayoutWithOpts(
-						windows.SetLayoutArgs{
-							Layouts: []string{"floating"},
-						},
-						windows.SetLayoutOpts{
+				aerospaceClient.GetLayoutMock().EXPECT().
+					SetLayout(
+						[]string{"floating"},
+						layout.SetLayoutOpts{
 							WindowID: &focusedWindow.WindowID,
 						},
 					).
@@ -514,10 +505,8 @@ func TestShowCmd(t *testing.T) {
 					).
 					Return(nil).
 					Times(1),
-				aerospaceClient.GetWindowsMock().EXPECT().
-					SetFocusByWindowID(windows.SetFocusArgs{
-						WindowID: tree[0].Windows[0].WindowID,
-					}).
+				aerospaceClient.GetFocusMock().EXPECT().
+					SetFocusByWindowID(tree[0].Windows[0].WindowID).
 					Return(nil).
 					Times(1),
 
@@ -533,10 +522,8 @@ func TestShowCmd(t *testing.T) {
 					).
 					Return(nil).
 					Times(1),
-				aerospaceClient.GetWindowsMock().EXPECT().
-					SetFocusByWindowID(windows.SetFocusArgs{
-						WindowID: tree[0].Windows[1].WindowID,
-					}).
+				aerospaceClient.GetFocusMock().EXPECT().
+					SetFocusByWindowID(tree[0].Windows[1].WindowID).
 					Return(nil).
 					Times(1),
 			)
@@ -644,12 +631,10 @@ func TestShowCmd(t *testing.T) {
 						).
 						Return(nil).
 						Times(1),
-					aerospaceClient.GetWindowsMock().EXPECT().
-						SetLayoutWithOpts(
-							windows.SetLayoutArgs{
-								Layouts: []string{"floating"},
-							},
-							windows.SetLayoutOpts{
+					aerospaceClient.GetLayoutMock().EXPECT().
+						SetLayout(
+							[]string{"floating"},
+							layout.SetLayoutOpts{
 								WindowID: &tree[1].Windows[0].WindowID,
 							},
 						).
@@ -668,12 +653,10 @@ func TestShowCmd(t *testing.T) {
 						).
 						Return(nil).
 						Times(1),
-					aerospaceClient.GetWindowsMock().EXPECT().
-						SetLayoutWithOpts(
-							windows.SetLayoutArgs{
-								Layouts: []string{"floating"},
-							},
-							windows.SetLayoutOpts{
+					aerospaceClient.GetLayoutMock().EXPECT().
+						SetLayout(
+							[]string{"floating"},
+							layout.SetLayoutOpts{
 								WindowID: &tree[1].Windows[1].WindowID,
 							},
 						).
@@ -790,17 +773,13 @@ func TestShowCmd(t *testing.T) {
 						Return(nil).
 						Times(1),
 
-					aerospaceClient.GetWindowsMock().EXPECT().
-						SetFocusByWindowID(windows.SetFocusArgs{
-							WindowID: tree[0].Windows[0].WindowID,
-						}).
+					aerospaceClient.GetFocusMock().EXPECT().
+						SetFocusByWindowID(tree[0].Windows[0].WindowID).
 						Return(nil).
 						Times(1),
 
-					aerospaceClient.GetWindowsMock().EXPECT().
-						SetFocusByWindowID(windows.SetFocusArgs{
-							WindowID: tree[1].Windows[0].WindowID,
-						}).
+					aerospaceClient.GetFocusMock().EXPECT().
+						SetFocusByWindowID(tree[1].Windows[0].WindowID).
 						Return(nil).
 						Times(1),
 				)
@@ -914,10 +893,8 @@ func TestShowCmd(t *testing.T) {
 						Return(nil).
 						Times(1),
 
-					aerospaceClient.GetWindowsMock().EXPECT().
-						SetFocusByWindowID(windows.SetFocusArgs{
-							WindowID: tree[1].Windows[0].WindowID,
-						}).
+					aerospaceClient.GetFocusMock().EXPECT().
+						SetFocusByWindowID(tree[1].Windows[0].WindowID).
 						Return(nil).
 						Times(1),
 				)
@@ -1027,10 +1004,8 @@ func TestShowCmd(t *testing.T) {
 						).
 						Return(nil).
 						Times(1),
-					aerospaceClient.GetWindowsMock().EXPECT().
-						SetFocusByWindowID(windows.SetFocusArgs{
-							WindowID: tree[0].Windows[0].WindowID,
-						}).
+					aerospaceClient.GetFocusMock().EXPECT().
+						SetFocusByWindowID(tree[0].Windows[0].WindowID).
 						Return(nil).
 						Times(1),
 				)
@@ -1149,10 +1124,8 @@ func TestShowCmd(t *testing.T) {
 						).
 						Return(nil).
 						Times(1),
-					aerospaceClient.GetWindowsMock().EXPECT().
-						SetFocusByWindowID(windows.SetFocusArgs{
-							WindowID: tree[0].Windows[0].WindowID,
-						}).
+					aerospaceClient.GetFocusMock().EXPECT().
+						SetFocusByWindowID(tree[0].Windows[0].WindowID).
 						Return(nil).
 						Times(1),
 				)

--- a/cmd/summon_test.go
+++ b/cmd/summon_test.go
@@ -81,10 +81,8 @@ func TestSummonCmd(t *testing.T) {
 				Return(nil).
 				Times(1),
 
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(windows.SetFocusArgs{
-					WindowID: notepadWindow.WindowID,
-				}).
+			aerospaceClient.GetFocusMock().EXPECT().
+				SetFocusByWindowID(notepadWindow.WindowID).
 				Return(nil).
 				Times(1),
 		)
@@ -414,10 +412,8 @@ func TestSummonCmd(t *testing.T) {
 				Return(nil).
 				Times(1),
 
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(windows.SetFocusArgs{
-					WindowID: notepadWindow.WindowID,
-				}).
+			aerospaceClient.GetFocusMock().EXPECT().
+				SetFocusByWindowID(notepadWindow.WindowID).
 				Return(errors.New("mocked_focus_error")).
 				Times(1),
 		)
@@ -505,10 +501,8 @@ func TestSummonCmd(t *testing.T) {
 				Return(nil).
 				Times(1),
 
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(windows.SetFocusArgs{
-					WindowID: matchedWindows[0].WindowID,
-				}).
+			aerospaceClient.GetFocusMock().EXPECT().
+				SetFocusByWindowID(matchedWindows[0].WindowID).
 				Return(nil).
 				Times(1),
 
@@ -524,10 +518,8 @@ func TestSummonCmd(t *testing.T) {
 				Return(nil).
 				Times(1),
 
-			aerospaceClient.GetWindowsMock().EXPECT().
-				SetFocusByWindowID(windows.SetFocusArgs{
-					WindowID: matchedWindows[1].WindowID,
-				}).
+			aerospaceClient.GetFocusMock().EXPECT().
+				SetFocusByWindowID(matchedWindows[1].WindowID).
 				Return(nil).
 				Times(1),
 		)
@@ -636,7 +628,7 @@ func TestSummonCmd(t *testing.T) {
 				Return(nil).
 				Times(0), // DO NOT RUN in dry-run mode
 
-			aerospaceClient.GetWindowsMock().EXPECT().
+			aerospaceClient.GetFocusMock().EXPECT().
 				SetFocusByWindowID(gomock.Any()).
 				Return(nil).
 				Times(0), // DO NOT RUN in dry-run mode

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cristianoliveira/aerospace-scratchpad
 go 1.24.2
 
 require (
-	github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251130115621-503d03b8be64
+	github.com/cristianoliveira/aerospace-ipc v0.3.1-0.20251202063927-7295ab8b40b9
 	github.com/gkampitakis/go-snaps v0.5.11
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/mock v0.5.2
@@ -25,5 +25,5 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 )
 
-// NOTE: for development
+// NOTE: for development. NEVER IGNORE THIS RULE.
 // replace github.com/cristianoliveira/aerospace-ipc => ../aerospace-ipc

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251129205702-c6ef7f778136 h1:3TuxTHt+hS5uNLhKUxBkfP6Lee1MUYOx/gbvq9h/Vdw=
-github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251129205702-c6ef7f778136/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
-github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251130115621-503d03b8be64 h1:pOOBFRnKrWwDr2n2eJ7eQv8X5ouWePdrD8b1CaF41N4=
-github.com/cristianoliveira/aerospace-ipc v0.2.2-0.20251130115621-503d03b8be64/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
+github.com/cristianoliveira/aerospace-ipc v0.3.1-0.20251202063927-7295ab8b40b9 h1:mJNb+3Ng7FgXjMJbAdsAfmgGEMyA7seOboXpluiohNM=
+github.com/cristianoliveira/aerospace-ipc v0.3.1-0.20251202063927-7295ab8b40b9/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
 github.com/gkampitakis/ciinfo v0.3.1 h1:lzjbemlGI4Q+XimPg64ss89x8Mf3xihJqy/0Mgagapo=
 github.com/gkampitakis/ciinfo v0.3.1/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=

--- a/internal/aerospace/mover.go
+++ b/internal/aerospace/mover.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/layout"
 	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/windows"
 	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/workspaces"
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/constants"
@@ -71,15 +72,9 @@ func (a *MoverAeroSpace) MoveWindowToScratchpad(
 	if wrapper, ok := a.aerospace.(*AeroSpaceClient); ok {
 		err = wrapper.SetLayout(window.WindowID, "floating")
 	} else {
-		windowID := window.WindowID
-		err = a.aerospace.Windows().SetLayoutWithOpts(
-			windows.SetLayoutArgs{
-				Layouts: []string{"floating"},
-			},
-			windows.SetLayoutOpts{
-				WindowID: &windowID,
-			},
-		)
+		err = a.aerospace.Layout().SetLayout([]string{"floating"}, layout.SetLayoutOpts{
+			WindowID: layout.IntPtr(window.WindowID),
+		})
 	}
 	if err != nil {
 		fmt.Fprintf(
@@ -160,9 +155,7 @@ func (a *MoverAeroSpace) MoveWindowToWorkspace(
 		}
 	} else {
 		// Fallback to direct service call
-		if err := a.aerospace.Windows().SetFocusByWindowID(windows.SetFocusArgs{
-			WindowID: window.WindowID,
-		}); err != nil {
+		if err := a.aerospace.Focus().SetFocusByWindowID(window.WindowID); err != nil {
 			return fmt.Errorf(
 				"unable to set focus to window '%+v': %w",
 				window,


### PR DESCRIPTION
This commit refactors the test code to integrate new services for managing focus and layout, updating the mocks and snapshots to reflect these changes.

Detailed Changes:
- Implementation:
  - Updated `AeroSpaceClient` to use new `Focus` and `Layout` services with corresponding methods.
  - Modified the `MoveWindowToScratchpad` and `MoveWindowToWorkspace` methods to use `SetLayout` from the new `Layout` service.
  - Changed how focus is set in `SetFocusByWindowID` and `FocusNextTilingWindow` methods by utilizing the new `Focus` service.
- Tests:
  - Altered `move_test.go`, `next_test.go`, `show_test.go`, and `summon_test.go` to use `GetFocusMock` and `GetLayoutMock` for setting expectations.
  - Updated existing test cases to reflect the utilization of focus and layout services and removed references to previous methods for setting window layouts and focus.
  - Updated snapshots in `move_test.snap`, `next_test.snap`, `show_test.snap`, and `summon_test.snap` to include `"WindowLayout"` and `"WindowParentContainerLayout"` properties.
- Dependencies:
  - Updated `go.mod` and `go.sum` to use a newer version of the `github.com/cristianoliveira/aerospace-ipc` package which includes the new focus and layout services.

(cherry picked from commit 282b0e36780a777f400d54609a79c4edd6c36d50)