### PR TITLE
chore: upgrade Go to 1.26.0

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
-          go-version: '^1.24' 
+          go-version: stable 
 
       - name: Install dependencies
         run: go mod download
@@ -42,4 +42,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.2
+          install-mode: goinstall

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       in {
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
-            go
+            go_1_26
 
             golangci-lint
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/cristianoliveira/aerospace-scratchpad
 
-go 1.24.2
+go 1.26.0
 
 require (
 	github.com/cristianoliveira/aerospace-ipc v0.3.1-0.20251202063927-7295ab8b40b9
 	github.com/gkampitakis/go-snaps v0.5.11
+	github.com/goccy/go-yaml v1.15.13
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/mock v0.5.2
 )
@@ -12,7 +13,6 @@ require (
 require (
 	github.com/gkampitakis/ciinfo v0.3.1 // indirect
 	github.com/gkampitakis/go-diff v1.3.2 // indirect
-	github.com/goccy/go-yaml v1.15.13 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect


### PR DESCRIPTION
Similar to the changes in [aerospace-marks](https://github.com/cristianoliveira/aerospace-marks/commits/develop), this PR upgrades Go from 1.24.2 to 1.26.0.

## Changes
- **Nix**: Upgrade devShell to use go_1_26
- **go.mod**: Update Go version to 1.26.0 and run go mod tidy