### PR TITLE
fix(summon): require pattern for summon command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ From [I3 User Guide](https://i3wm.org/docs/userguide.html#_scratchpad):
 
 ## Basic Usage
 
-Summon or move a window from the scratchpad workspace to the current workspace.
+Show, summon, or move a matching window by app-name pattern.
 ```text
 aerospace-scratchpad show <pattern>
+aerospace-scratchpad summon <pattern>
 ```
 
 To find the correct `pattern` run `aerospace list-windows --all --json | grep app-name`
@@ -69,13 +70,13 @@ aerospace-scratchpad move --all-floating
 # This toggle the scratchpad window show/hide
 cmd-ctrl-1 = "exec-and-forget aerospace-scratchpad show Finder"
 
-# Or using summon instead
+# Or using summon instead: bring matching window to current workspace without toggling it back
 cmd-ctrl-2 = """
 exec-and-forget aerospace-scratchpad summon Finder || \
                 aerospace-scratchpad move Finder
 """
 
-# Bring windows one by one to current workspace
+# Cycle scratchpad windows without specifying a pattern
 ctrl-minus = "exec-and-forget aerospace-scratchpad next"
 
 # Hide all scratchpad windows at once

--- a/cmd/__snapshots__/summon_test.snap
+++ b/cmd/__snapshots__/summon_test.snap
@@ -196,3 +196,17 @@ Output:
   error: ""
 
 ---
+
+
+[TestSummonCmd/fails_when_pattern_is_omitted - 1]
+Context:
+  {}
+Command: |
+  $ aerospace-scratchpad summon
+Output:
+  status: error
+  stdout: ""
+  error: |
+    accepts 1 arg(s), received 0
+
+---

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -54,7 +54,7 @@ func parseMonitorFlag(cmd *cobra.Command) (int, error) {
 // ListCmd represents the list command.
 func ListCmd(aerospaceClient *aerospace.AeroSpaceClient) *cobra.Command {
 	command := &cobra.Command{
-		Use:     "list",
+		Use:     commandList,
 		Aliases: []string{"ls"},
 		Short:   "List scratchpad windows",
 		Long: `List all scratchpad windows.
@@ -175,7 +175,7 @@ func outputWindows(formatter *cli.OutputFormatter, windows []windowsipc.Window) 
 
 	if len(windows) == 0 {
 		if printErr := formatter.Print(cli.OutputEvent{
-			Command:   "list",
+			Command:   commandList,
 			Action:    "list",
 			Result:    "none",
 			Message:   "no scratchpad windows found",
@@ -188,7 +188,7 @@ func outputWindows(formatter *cli.OutputFormatter, windows []windowsipc.Window) 
 
 	for _, window := range windows {
 		if printErr := formatter.Print(cli.OutputEvent{
-			Command:   "list",
+			Command:   commandList,
 			Action:    "list",
 			WindowID:  window.WindowID,
 			AppName:   window.AppName,

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -165,8 +165,8 @@ To move all floating windows (scratchpad windows) to the scratchpad, use the --a
 			// When using --all-floating, skip the focused window check
 			if allFloatingFlag && len(windows) == 0 {
 				if printErr := formatter.Print(cli.OutputEvent{
-					Command:   "move",
-					Action:    "to-scratchpad",
+					Command:   commandMove,
+					Action:    actionToScratchpad,
 					Result:    "none",
 					Message:   "no floating windows found",
 					Workspace: "",
@@ -198,8 +198,8 @@ To move all floating windows (scratchpad windows) to the scratchpad, use the --a
 						"already belongs to workspace",
 					) {
 						if printErr := formatter.Print(cli.OutputEvent{
-							Command:         "move",
-							Action:          "to-scratchpad",
+							Command:         commandMove,
+							Action:          actionToScratchpad,
 							WindowID:        window.WindowID,
 							AppName:         window.AppName,
 							Workspace:       window.Workspace,
@@ -223,8 +223,8 @@ To move all floating windows (scratchpad windows) to the scratchpad, use the --a
 				}
 
 				if printErr := formatter.Print(cli.OutputEvent{
-					Command:         "move",
-					Action:          "to-scratchpad",
+					Command:         commandMove,
+					Action:          actionToScratchpad,
 					WindowID:        window.WindowID,
 					AppName:         window.AppName,
 					Workspace:       window.Workspace,

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -70,8 +70,8 @@ It does not send the windows back to the scratchpad, but rather focuses the next
 			}
 
 			if printErr := formatter.Print(cli.OutputEvent{
-				Command:         "next",
-				Action:          "to-workspace",
+				Command:         commandNext,
+				Action:          actionToWorkspace,
 				WindowID:        window.WindowID,
 				AppName:         window.AppName,
 				Workspace:       window.Workspace,

--- a/cmd/output_constants.go
+++ b/cmd/output_constants.go
@@ -1,0 +1,12 @@
+package cmd
+
+const (
+	commandList   = "list"
+	commandMove   = "move"
+	commandNext   = "next"
+	commandShow   = "show"
+	commandSummon = "summon"
+
+	actionToWorkspace  = "to-workspace"
+	actionToScratchpad = "to-scratchpad"
+)

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -172,8 +172,8 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 				}
 
 				if printErr := formatter.Print(cli.OutputEvent{
-					Command:         "show",
-					Action:          "to-workspace",
+					Command:         commandShow,
+					Action:          actionToWorkspace,
 					WindowID:        window.WindowID,
 					AppName:         window.AppName,
 					Workspace:       window.Workspace,
@@ -204,7 +204,7 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 						window,
 					)
 					if printErr := formatter.Print(cli.OutputEvent{
-						Command:   "show",
+						Command:   commandShow,
 						Action:    "focus",
 						WindowID:  window.WindowID,
 						AppName:   window.AppName,
@@ -237,8 +237,8 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 							moveErr,
 						)
 						if printErr := formatter.Print(cli.OutputEvent{
-							Command:         "show",
-							Action:          "to-scratchpad",
+							Command:         commandShow,
+							Action:          actionToScratchpad,
 							WindowID:        window.WindowID,
 							AppName:         window.AppName,
 							Workspace:       window.Workspace,
@@ -252,8 +252,8 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 					}
 
 					if printErr := formatter.Print(cli.OutputEvent{
-						Command:         "show",
-						Action:          "to-scratchpad",
+						Command:         commandShow,
+						Action:          actionToScratchpad,
 						WindowID:        window.WindowID,
 						AppName:         window.AppName,
 						Workspace:       window.Workspace,
@@ -275,7 +275,7 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 					return
 				}
 				if printErr := formatter.Print(cli.OutputEvent{
-					Command:   "show",
+					Command:   commandShow,
 					Action:    "focus",
 					WindowID:  window.WindowID,
 					AppName:   window.AppName,

--- a/cmd/summon.go
+++ b/cmd/summon.go
@@ -23,11 +23,11 @@ func SummonCmd(
 ) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "summon <pattern>",
-		Short: "Summon a window from scratchpad",
-		Long: `Summon a window from the scratchpad to the current workspace.
+		Short: "Summon a matching window to the current workspace",
+		Long: `Summon a matching window to the current workspace.
 
-This command brings a window from the scratchpad to the current workspace using a regex to match the window name or title.
-If no pattern is provided, it summons the first window in the scratchpad.
+This command brings windows matching the regex pattern to the current workspace and focuses them.
+Use "next" to cycle through scratchpad windows without specifying a pattern.
 `,
 
 		Args: cobra.MatchAll(
@@ -114,7 +114,8 @@ If no pattern is provided, it summons the first window in the scratchpad.
 							"error",
 							moveErr,
 						)
-						if focusErr := aerospaceClient.SetFocusByWindowID(window.WindowID); focusErr != nil {
+						focusErr := aerospaceClient.SetFocusByWindowID(window.WindowID)
+						if focusErr != nil {
 							logger.LogError(
 								"SUMMON: unable to set focus to window",
 								"window",
@@ -131,8 +132,8 @@ If no pattern is provided, it summons the first window in the scratchpad.
 						}
 
 						if printErr := formatter.Print(cli.OutputEvent{
-							Command:         "summon",
-							Action:          "to-workspace",
+							Command:         commandSummon,
+							Action:          actionToWorkspace,
 							WindowID:        window.WindowID,
 							AppName:         window.AppName,
 							Workspace:       window.Workspace,
@@ -159,8 +160,8 @@ If no pattern is provided, it summons the first window in the scratchpad.
 				}
 
 				if printErr := formatter.Print(cli.OutputEvent{
-					Command:         "summon",
-					Action:          "to-workspace",
+					Command:         commandSummon,
+					Action:          actionToWorkspace,
 					WindowID:        window.WindowID,
 					AppName:         window.AppName,
 					Workspace:       window.Workspace,

--- a/cmd/summon_test.go
+++ b/cmd/summon_test.go
@@ -97,6 +97,24 @@ func TestSummonCmd(t *testing.T) {
 		testutils.MatchSnapshot(t, tree, cmdAsString, out, err)
 	})
 
+	t.Run("fails when pattern is omitted", func(t *testing.T) {
+		command := "summon"
+		args := []string{command}
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
+		cmd := cmd.RootCmd(aerospaceClient)
+		out, err := testutils.CmdExecute(cmd, args...)
+		if err == nil {
+			t.Errorf("Expected error when pattern is omitted, got nil")
+		}
+
+		cmdAsString := "aerospace-scratchpad " + strings.Join(args, " ")
+		testutils.MatchSnapshot(t, nil, cmdAsString, out, err)
+	})
+
 	t.Run("fails when pattern doesn't match any window", func(t *testing.T) {
 		command := "summon"
 		args := []string{command, "NonExistentApp"}

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,9 @@ See also [flags](#flags).
 
 ## Command: `summon`
 
-Unlike the `show` command, this command will only summon the window to the current workspace and set focus on it.
+Like `show`, this command requires a pattern. Unlike `show`, it only brings matching windows to the current workspace and focuses them; it does not toggle visible windows back to scratchpad.
+
+Use `next` when you want to cycle through scratchpad windows without specifying a pattern.
 
 ### USAGE
 
@@ -99,7 +101,7 @@ See also [flags](#flags).
 
 ## Command: `next`
 
-This command will summon the next window from the scratchpad workspace until there are no more windows to summon.
+This command cycles through scratchpad windows and summons the next one to the current workspace.
 
 ### USAGE
 

--- a/internal/aerospace/mover.go
+++ b/internal/aerospace/mover.go
@@ -298,9 +298,9 @@ func (a *MoverAeroSpace) moveWindowToScratchpadWorkspace(
 
 	// Use wrapper's SetLayout if available (for dry-run support)
 	if wrapper, ok := a.aerospace.(*AeroSpaceClient); ok {
-		err = wrapper.SetLayout(window.WindowID, "floating")
+		err = wrapper.SetLayout(window.WindowID, floatingLayout)
 	} else {
-		err = a.aerospace.Layout().SetLayout([]string{"floating"}, layout.SetLayoutOpts{
+		err = a.aerospace.Layout().SetLayout([]string{floatingLayout}, layout.SetLayoutOpts{
 			WindowID: layout.IntPtr(window.WindowID),
 		})
 	}

--- a/internal/aerospace/querier.go
+++ b/internal/aerospace/querier.go
@@ -52,7 +52,7 @@ type Querier interface {
 	// GetScratchpadWindows returns all scratchpad windows
 	// A scratchpad window is defined as:
 	// - A window in a scratchpad workspace (.scratchpad or .scratchpad.<monitor-id>), OR
-	// - A floating window (WindowLayout == "floating")
+	// - A floating window (WindowLayout == floatingLayout)
 	GetScratchpadWindows() ([]windows.Window, error)
 
 	// GetScratchpadWindowsForMonitor returns scratchpad windows filtered by monitor.
@@ -106,6 +106,8 @@ type nextState struct {
 const (
 	listWorkspacesMonitorFormat = "%{workspace} %{monitor-id}"
 	focusedMonitorFormat        = "%{monitor-id} %{monitor-name}"
+	jsonFlag                    = "--json"
+	formatFlag                  = "--format"
 	nextStateFileName           = "next-state.json"
 	filterLogPrefix             = "FILTER: "
 	floatingLayout              = "floating"
@@ -212,8 +214,8 @@ func ListWorkspacesWithMonitors(cli AeroSpaceWMClient) ([]WorkspaceMonitor, erro
 		"list-workspaces",
 		[]string{
 			"--all",
-			"--json",
-			"--format",
+			jsonFlag,
+			formatFlag,
 			listWorkspacesMonitorFormat,
 		},
 	)
@@ -253,8 +255,8 @@ func GetFocusedMonitor(cli AeroSpaceWMClient) (*MonitorInfo, error) {
 		"list-monitors",
 		[]string{
 			"--focused",
-			"--json",
-			"--format",
+			jsonFlag,
+			formatFlag,
 			focusedMonitorFormat,
 		},
 	)
@@ -288,8 +290,8 @@ func ListMonitors(cli AeroSpaceWMClient) ([]MonitorInfo, error) {
 	response, err := cli.Connection().SendCommand(
 		"list-monitors",
 		[]string{
-			"--json",
-			"--format",
+			jsonFlag,
+			formatFlag,
 			focusedMonitorFormat,
 		},
 	)
@@ -523,7 +525,7 @@ func (a *QueryMaker) GetAllFloatingWindows() ([]windows.Window, error) {
 
 	var floatingWindows []windows.Window
 	for _, window := range allWindows {
-		if window.WindowLayout == "floating" {
+		if window.WindowLayout == floatingLayout {
 			floatingWindows = append(floatingWindows, window)
 		}
 	}
@@ -580,7 +582,7 @@ func (a *QueryMaker) GetScratchpadWindows() ([]windows.Window, error) {
 
 	// Add floating windows
 	for _, window := range allWindows {
-		if window.WindowLayout == "floating" {
+		if window.WindowLayout == floatingLayout {
 			// Only add if not already in map (avoid duplicates)
 			if _, exists := scratchpadWindowMap[window.WindowID]; !exists {
 				scratchpadWindowMap[window.WindowID] = window

--- a/internal/aerospace/querier_test.go
+++ b/internal/aerospace/querier_test.go
@@ -602,7 +602,9 @@ func TestAeroSpaceQuerier(t *testing.T) {
 			}, nil).
 			Times(1)
 
-		if _, err := aerospace.ListWorkspacesWithMonitors(&mockConnectionAeroSpaceClient{conn: socket}); err == nil {
+		if _, err := aerospace.ListWorkspacesWithMonitors(
+			&mockConnectionAeroSpaceClient{conn: socket},
+		); err == nil {
 			t.Fatalf("expected error when command fails")
 		}
 	})
@@ -648,7 +650,9 @@ func TestAeroSpaceQuerier(t *testing.T) {
 			}, nil).
 			Times(1)
 
-		if _, err := aerospace.GetFocusedMonitor(&mockConnectionAeroSpaceClient{conn: socket}); err == nil {
+		if _, err := aerospace.GetFocusedMonitor(
+			&mockConnectionAeroSpaceClient{conn: socket},
+		); err == nil {
 			t.Fatalf("expected error when no focused monitor is returned")
 		}
 	})

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -124,6 +124,7 @@ func NewLogger() (Logger, error) {
 		path = "/tmp/aerospace-scratchpad.log"
 	}
 
+	// #nosec G304,G703 -- log path is intentionally configurable via env var.
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open log file: %w", err)


### PR DESCRIPTION
## Summary
- require a pattern for `summon`, matching `show` semantics
- clarify docs: use `next` for no-pattern scratchpad cycling
- clean up lint findings with shared constants and explicit log-path gosec suppression

## Validation
- `make lint`
- `make test`