### PR TITLE
feat: add pinned scratchpad rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,13 @@ aerospace-scratchpad pin ".*Brave.*"
 
 # Pin a specific terminal scratchpad rule
 aerospace-scratchpad pin ".*Alacritty.*" --filter window-title="terminal-scratchpad"
+
+# Temporarily disable or re-enable a saved pattern rule without deleting it
+aerospace-scratchpad pin --disable ".*Brave.*"
+aerospace-scratchpad pin --enable ".*Brave.*"
 ```
 
-When `[pattern]` is omitted, the focused window is pinned or unpinned by window ID. When `[pattern]` is provided, the pin is saved as a rule, so future windows matching the same app-name regex and filters are pinned too.
+When `[pattern]` is omitted, the focused window is pinned or unpinned by window ID. When `[pattern]` is provided, the pin is saved as a rule, so future windows matching the same app-name regex and filters are pinned too. Use `pin --disable [pattern]` and `pin --enable [pattern]` to toggle a saved rule without removing it.
 
 Pinned state is stored at `~/.config/aerospace-scratchpad/pinned.json`. For tests or custom setups, override it with `AEROSPACE_SCRATCHPAD_PINS_PATH`.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ aerospace-scratchpad pin ".*Alacritty.*" --filter window-title="terminal-scratch
 
 When `[pattern]` is omitted, the focused window is pinned or unpinned by window ID. When `[pattern]` is provided, the pin is saved as a rule, so future windows matching the same app-name regex and filters are pinned too.
 
+Pinned state is stored at `~/.config/aerospace-scratchpad/pinned.json`. For tests or custom setups, override it with `AEROSPACE_SCRATCHPAD_PINS_PATH`.
+
 ### Config Usage
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -62,6 +62,27 @@ Move all floating windows (scratchpad windows) to the scratchpad:
 aerospace-scratchpad move --all-floating
 ```
 
+Pin a scratchpad window to its current monitor so `show`, `summon`, and `next` focus it there instead of moving it to the focused monitor:
+```text
+aerospace-scratchpad pin [pattern]
+aerospace-scratchpad unpin [pattern]
+```
+
+Pin follows the same pattern rules as `show`, `summon`, and `move`: `[pattern]` is a regular expression matched against app name and can be combined with `--filter`.
+
+```text
+# Pin current focused window by window ID
+aerospace-scratchpad pin
+
+# Pin every current and future Brave window to the matched window's current monitor
+aerospace-scratchpad pin ".*Brave.*"
+
+# Pin a specific terminal scratchpad rule
+aerospace-scratchpad pin ".*Alacritty.*" --filter window-title="terminal-scratchpad"
+```
+
+When `[pattern]` is omitted, the focused window is pinned or unpinned by window ID. When `[pattern]` is provided, the pin is saved as a rule, so future windows matching the same app-name regex and filters are pinned too.
+
 ### Config Usage
 
 ```toml

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -41,6 +41,14 @@ It does not send the windows back to the scratchpad, but rather focuses the next
 				return
 			}
 
+			currentMonitorID := 0
+			monitor, monitorErr := aerospace.GetFocusedMonitor(
+				aerospaceClient.GetUnderlyingClient(),
+			)
+			if monitorErr == nil {
+				currentMonitorID = monitor.MonitorID
+			}
+
 			focusedWorkspace, err := aerospaceClient.GetFocusedWorkspace()
 			if err != nil {
 				stderr.Println(
@@ -56,6 +64,21 @@ It does not send the windows back to the scratchpad, but rather focuses the next
 			window, err := querier.GetNextScratchpadWindowForMonitor(monitorID)
 			if err != nil {
 				stderr.Println("Error: %v", err)
+				return
+			}
+
+			handled, err := focusPinnedWindowOnOtherMonitor(
+				commandNext,
+				aerospaceClient,
+				formatter,
+				*window,
+				currentMonitorID,
+			)
+			if err != nil {
+				stderr.Println("Error: %v", err)
+				return
+			}
+			if handled {
 				return
 			}
 

--- a/cmd/output_constants.go
+++ b/cmd/output_constants.go
@@ -4,9 +4,12 @@ const (
 	commandList   = "list"
 	commandMove   = "move"
 	commandNext   = "next"
+	commandPin    = "pin"
 	commandShow   = "show"
 	commandSummon = "summon"
+	commandUnpin  = "unpin"
 
+	actionFocus        = "focus"
 	actionToWorkspace  = "to-workspace"
 	actionToScratchpad = "to-scratchpad"
 )

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"strconv"
 	"strings"
@@ -20,54 +21,11 @@ func PinCmd(aerospaceClient *aerospace.AeroSpaceClient) *cobra.Command {
 		Short: "Pin a scratchpad window to its current monitor",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			logger := logger.GetDefaultLogger()
-			formatter, err := outputFormatterFrom(cmd)
-			if err != nil {
-				stderr.Println("Error: %v", err)
-				return
-			}
-
-			windows, err := windowsForOptionalPattern(cmd, args, aerospaceClient)
-			if err != nil {
-				stderr.Println("Error: %v", err)
-				return
-			}
-
-			filterFlags, err := cmd.Flags().GetStringArray("filter")
-			if err != nil {
-				stderr.Println("Error: %v", err)
-				return
-			}
-			pattern := optionalPattern(args)
-
-			for _, window := range windows {
-				monitorID, resolveErr := aerospace.ResolveWindowMonitorID(
-					aerospaceClient.GetUnderlyingClient(),
-					window,
-				)
-				if resolveErr != nil {
-					stderr.Println("Error: %v", resolveErr)
-					return
-				}
-				pinErr := pinWindowOrRule(pattern, filterFlags, window.WindowID, monitorID)
-				if pinErr != nil {
-					stderr.Println("Error: %v", pinErr)
-					return
-				}
-				if printErr := formatter.Print(cli.OutputEvent{
-					Command:   commandPin,
-					Action:    "pin",
-					WindowID:  window.WindowID,
-					AppName:   window.AppName,
-					Workspace: window.Workspace,
-					Result:    "ok",
-					Message:   "pinned to monitor " + strconv.Itoa(monitorID),
-				}); printErr != nil {
-					logger.LogError("PIN: unable to write output", "error", printErr)
-				}
-			}
+			handlePinCommand(cmd, args, aerospaceClient)
 		},
 	}
+	command.Flags().Bool("disable", false, "Disable a saved pin rule without removing it")
+	command.Flags().Bool("enable", false, "Enable a saved pin rule")
 	return command
 }
 
@@ -124,6 +82,83 @@ func UnpinCmd(aerospaceClient *aerospace.AeroSpaceClient) *cobra.Command {
 		},
 	}
 	return command
+}
+
+func handlePinCommand(
+	cmd *cobra.Command,
+	args []string,
+	aerospaceClient *aerospace.AeroSpaceClient,
+) {
+	logger := logger.GetDefaultLogger()
+	disableRule, _ := cmd.Flags().GetBool("disable")
+	enableRule, _ := cmd.Flags().GetBool("enable")
+	if disableRule && enableRule {
+		stderr.Println("Error: --enable and --disable cannot be used together")
+		return
+	}
+	if disableRule || enableRule {
+		if err := setPinRuleState(cmd, args, enableRule); err != nil {
+			stderr.Println("Error: %v", err)
+		}
+		return
+	}
+
+	formatter, err := outputFormatterFrom(cmd)
+	if err != nil {
+		stderr.Println("Error: %v", err)
+		return
+	}
+
+	windows, err := windowsForOptionalPattern(cmd, args, aerospaceClient)
+	if err != nil {
+		stderr.Println("Error: %v", err)
+		return
+	}
+
+	filterFlags, err := cmd.Flags().GetStringArray("filter")
+	if err != nil {
+		stderr.Println("Error: %v", err)
+		return
+	}
+	pattern := optionalPattern(args)
+
+	for _, window := range windows {
+		monitorID, resolveErr := aerospace.ResolveWindowMonitorID(
+			aerospaceClient.GetUnderlyingClient(),
+			window,
+		)
+		if resolveErr != nil {
+			stderr.Println("Error: %v", resolveErr)
+			return
+		}
+		pinErr := pinWindowOrRule(pattern, filterFlags, window.WindowID, monitorID)
+		if pinErr != nil {
+			stderr.Println("Error: %v", pinErr)
+			return
+		}
+		if printErr := formatter.Print(cli.OutputEvent{
+			Command:   commandPin,
+			Action:    "pin",
+			WindowID:  window.WindowID,
+			AppName:   window.AppName,
+			Workspace: window.Workspace,
+			Result:    "ok",
+			Message:   "pinned to monitor " + strconv.Itoa(monitorID),
+		}); printErr != nil {
+			logger.LogError("PIN: unable to write output", "error", printErr)
+		}
+	}
+}
+
+func setPinRuleState(cmd *cobra.Command, args []string, enabled bool) error {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return errors.New("pattern is required when using --enable or --disable")
+	}
+	filterFlags, err := cmd.Flags().GetStringArray("filter")
+	if err != nil {
+		return err
+	}
+	return aerospace.SetPinRuleEnabled(strings.TrimSpace(args[0]), filterFlags, enabled)
 }
 
 func outputFormatterFrom(cmd *cobra.Command) (*cli.OutputFormatter, error) {

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	windowsipc "github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/windows"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/aerospace"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/cli"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/logger"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/stderr"
+)
+
+func PinCmd(aerospaceClient *aerospace.AeroSpaceClient) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "pin [pattern]",
+		Short: "Pin a scratchpad window to its current monitor",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			logger := logger.GetDefaultLogger()
+			formatter, err := outputFormatterFrom(cmd)
+			if err != nil {
+				stderr.Println("Error: %v", err)
+				return
+			}
+
+			windows, err := windowsForOptionalPattern(cmd, args, aerospaceClient)
+			if err != nil {
+				stderr.Println("Error: %v", err)
+				return
+			}
+
+			filterFlags, err := cmd.Flags().GetStringArray("filter")
+			if err != nil {
+				stderr.Println("Error: %v", err)
+				return
+			}
+			pattern := optionalPattern(args)
+
+			for _, window := range windows {
+				monitorID, resolveErr := aerospace.ResolveWindowMonitorID(
+					aerospaceClient.GetUnderlyingClient(),
+					window,
+				)
+				if resolveErr != nil {
+					stderr.Println("Error: %v", resolveErr)
+					return
+				}
+				pinErr := pinWindowOrRule(pattern, filterFlags, window.WindowID, monitorID)
+				if pinErr != nil {
+					stderr.Println("Error: %v", pinErr)
+					return
+				}
+				if printErr := formatter.Print(cli.OutputEvent{
+					Command:   commandPin,
+					Action:    "pin",
+					WindowID:  window.WindowID,
+					AppName:   window.AppName,
+					Workspace: window.Workspace,
+					Result:    "ok",
+					Message:   "pinned to monitor " + strconv.Itoa(monitorID),
+				}); printErr != nil {
+					logger.LogError("PIN: unable to write output", "error", printErr)
+				}
+			}
+		},
+	}
+	return command
+}
+
+func UnpinCmd(aerospaceClient *aerospace.AeroSpaceClient) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "unpin [pattern]",
+		Short: "Unpin a scratchpad window",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			logger := logger.GetDefaultLogger()
+			formatter, err := outputFormatterFrom(cmd)
+			if err != nil {
+				stderr.Println("Error: %v", err)
+				return
+			}
+
+			windows, err := windowsForOptionalPattern(cmd, args, aerospaceClient)
+			if err != nil {
+				stderr.Println("Error: %v", err)
+				return
+			}
+
+			filterFlags, err := cmd.Flags().GetStringArray("filter")
+			if err != nil {
+				stderr.Println("Error: %v", err)
+				return
+			}
+			pattern := optionalPattern(args)
+			if pattern != "" {
+				unpinErr := aerospace.UnpinRuleForPattern(pattern, filterFlags)
+				if unpinErr != nil {
+					stderr.Println("Error: %v", unpinErr)
+					return
+				}
+			}
+
+			for _, window := range windows {
+				unpinErr := aerospace.UnpinWindow(window.WindowID)
+				if unpinErr != nil {
+					stderr.Println("Error: %v", unpinErr)
+					return
+				}
+				if printErr := formatter.Print(cli.OutputEvent{
+					Command:   commandUnpin,
+					Action:    "unpin",
+					WindowID:  window.WindowID,
+					AppName:   window.AppName,
+					Workspace: window.Workspace,
+					Result:    "ok",
+				}); printErr != nil {
+					logger.LogError("UNPIN: unable to write output", "error", printErr)
+				}
+			}
+		},
+	}
+	return command
+}
+
+func outputFormatterFrom(cmd *cobra.Command) (*cli.OutputFormatter, error) {
+	outputFormat, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return nil, err
+	}
+	return cli.NewOutputFormatter(os.Stdout, outputFormat)
+}
+
+func pinWindowOrRule(pattern string, filters []string, windowID int, monitorID int) error {
+	if pattern != "" {
+		return aerospace.PinRuleForPattern(pattern, filters, monitorID)
+	}
+	return aerospace.PinWindow(windowID, monitorID)
+}
+
+func optionalPattern(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(args[0])
+}
+
+func windowsForOptionalPattern(
+	cmd *cobra.Command,
+	args []string,
+	aerospaceClient *aerospace.AeroSpaceClient,
+) ([]windowsipc.Window, error) {
+	if optionalPattern(args) == "" {
+		window, err := aerospaceClient.GetFocusedWindow()
+		if err != nil {
+			return nil, err
+		}
+		return []windowsipc.Window{*window}, nil
+	}
+
+	filterFlags, err := cmd.Flags().GetStringArray("filter")
+	if err != nil {
+		return nil, err
+	}
+	querier := aerospace.NewAerospaceQuerier(aerospaceClient.GetUnderlyingClient())
+	return querier.GetFilteredWindows(optionalPattern(args), filterFlags)
+}

--- a/cmd/pin_test.go
+++ b/cmd/pin_test.go
@@ -1,0 +1,184 @@
+package cmd_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/windows"
+	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/workspaces"
+	"github.com/cristianoliveira/aerospace-scratchpad/cmd"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/aerospace"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/logger"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/stderr"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/testutils"
+)
+
+func TestPinCmdPinsFocusedWindowToCurrentMonitor(t *testing.T) {
+	logger.SetDefaultLogger(&logger.EmptyLogger{})
+	stderr.SetBehavior(false)
+	t.Setenv("AEROSPACE_SCRATCHPAD_PINS_PATH", filepath.Join(t.TempDir(), "pins.json"))
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	focusedWindow := &windows.Window{
+		WindowID:  1234,
+		AppName:   "Finder",
+		Workspace: "ws2",
+	}
+	aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
+	aerospaceClient.SetWorkspaceMonitors([]aerospace.WorkspaceMonitor{
+		{Workspace: "ws2", MonitorID: 2},
+	})
+	aerospaceClient.SetFocusedMonitor(aerospace.MonitorInfo{MonitorID: 1})
+
+	aerospaceClient.GetWindowsMock().EXPECT().
+		GetFocusedWindow().
+		Return(focusedWindow, nil).
+		Times(1)
+
+	rootCmd := cmd.RootCmd(aerospaceClient)
+	_, err := testutils.CmdExecute(rootCmd, "pin")
+	if err != nil {
+		t.Fatalf("pin command failed: %v", err)
+	}
+
+	monitorID, ok, err := aerospace.PinnedMonitorID(focusedWindow.WindowID)
+	if err != nil {
+		t.Fatalf("read pin: %v", err)
+	}
+	if !ok || monitorID != 2 {
+		t.Fatalf(
+			"expected window pinned to its workspace monitor 2, got ok=%v monitor=%d",
+			ok,
+			monitorID,
+		)
+	}
+}
+
+func TestPinCmdStoresPatternRule(t *testing.T) {
+	logger.SetDefaultLogger(&logger.EmptyLogger{})
+	stderr.SetBehavior(false)
+	t.Setenv("AEROSPACE_SCRATCHPAD_PINS_PATH", filepath.Join(t.TempDir(), "pins.json"))
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	braveWindow := windows.Window{
+		WindowID:  1234,
+		AppName:   "Brave Browser",
+		Workspace: "ws2",
+	}
+	aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
+	aerospaceClient.SetWorkspaceMonitors([]aerospace.WorkspaceMonitor{
+		{Workspace: "ws2", MonitorID: 2},
+	})
+	aerospaceClient.GetWindowsMock().EXPECT().
+		GetAllWindows().
+		Return([]windows.Window{braveWindow}, nil).
+		Times(1)
+
+	rootCmd := cmd.RootCmd(aerospaceClient)
+	_, err := testutils.CmdExecute(rootCmd, "pin", ".*Brave.*")
+	if err != nil {
+		t.Fatalf("pin command failed: %v", err)
+	}
+
+	monitorID, ok, err := aerospace.PinnedMonitorIDForWindow(windows.Window{
+		WindowID: 9876,
+		AppName:  "Brave Browser",
+	})
+	if err != nil {
+		t.Fatalf("read pin rule: %v", err)
+	}
+	if !ok || monitorID != 2 {
+		t.Fatalf(
+			"expected future Brave window pinned to monitor 2, got ok=%v monitor=%d",
+			ok,
+			monitorID,
+		)
+	}
+}
+
+func TestUnpinCmdRemovesFocusedWindowPin(t *testing.T) {
+	logger.SetDefaultLogger(&logger.EmptyLogger{})
+	stderr.SetBehavior(false)
+	t.Setenv("AEROSPACE_SCRATCHPAD_PINS_PATH", filepath.Join(t.TempDir(), "pins.json"))
+
+	if err := aerospace.PinWindow(1234, 2); err != nil {
+		t.Fatalf("seed pin: %v", err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	focusedWindow := &windows.Window{
+		WindowID:  1234,
+		AppName:   "Finder",
+		Workspace: "ws2",
+	}
+	aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
+	aerospaceClient.GetWindowsMock().EXPECT().
+		GetFocusedWindow().
+		Return(focusedWindow, nil).
+		Times(1)
+
+	rootCmd := cmd.RootCmd(aerospaceClient)
+	_, err := testutils.CmdExecute(rootCmd, "unpin")
+	if err != nil {
+		t.Fatalf("unpin command failed: %v", err)
+	}
+
+	_, ok, err := aerospace.PinnedMonitorID(focusedWindow.WindowID)
+	if err != nil {
+		t.Fatalf("read pin: %v", err)
+	}
+	if ok {
+		t.Fatal("expected window to be unpinned")
+	}
+}
+
+func TestPinnedSummonFocusesWindowOnOtherMonitorWithoutMoving(t *testing.T) {
+	logger.SetDefaultLogger(&logger.EmptyLogger{})
+	stderr.SetBehavior(false)
+	t.Setenv("AEROSPACE_SCRATCHPAD_PINS_PATH", filepath.Join(t.TempDir(), "pins.json"))
+
+	seedErr := aerospace.PinWindow(1234, 2)
+	if seedErr != nil {
+		t.Fatalf("seed pin: %v", seedErr)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pinnedWindow := windows.Window{
+		WindowID:  1234,
+		AppName:   "Finder",
+		Workspace: ".scratchpad.2",
+	}
+	aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
+	aerospaceClient.SetFocusedMonitor(aerospace.MonitorInfo{MonitorID: 1})
+
+	gomock.InOrder(
+		aerospaceClient.GetWorkspacesMock().EXPECT().
+			GetFocusedWorkspace().
+			Return(&workspaces.Workspace{Workspace: "ws1"}, nil).
+			Times(1),
+		aerospaceClient.GetWindowsMock().EXPECT().
+			GetAllWindows().
+			Return([]windows.Window{pinnedWindow}, nil).
+			Times(1),
+		aerospaceClient.GetFocusMock().EXPECT().
+			SetFocusByWindowID(pinnedWindow.WindowID).
+			Return(nil).
+			Times(1),
+	)
+
+	rootCmd := cmd.RootCmd(aerospaceClient)
+	_, err := testutils.CmdExecute(rootCmd, "summon", "Finder")
+	if err != nil {
+		t.Fatalf("summon command failed: %v", err)
+	}
+}

--- a/cmd/pin_test.go
+++ b/cmd/pin_test.go
@@ -102,6 +102,50 @@ func TestPinCmdStoresPatternRule(t *testing.T) {
 	}
 }
 
+func TestPinCmdDisablesAndEnablesPatternRule(t *testing.T) {
+	logger.SetDefaultLogger(&logger.EmptyLogger{})
+	stderr.SetBehavior(false)
+	t.Setenv("AEROSPACE_SCRATCHPAD_PINS_PATH", filepath.Join(t.TempDir(), "pins.json"))
+
+	if err := aerospace.PinRuleForPattern(".*Brave.*", nil, 2); err != nil {
+		t.Fatalf("seed pin rule: %v", err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	aerospaceClient := testutils.NewMockAeroSpaceWM(ctrl)
+	rootCmd := cmd.RootCmd(aerospaceClient)
+
+	_, err := testutils.CmdExecute(rootCmd, "pin", "--disable", ".*Brave.*")
+	if err != nil {
+		t.Fatalf("disable pin rule command failed: %v", err)
+	}
+	_, ok, err := aerospace.PinnedMonitorIDForWindow(windows.Window{
+		AppName: "Brave Browser",
+	})
+	if err != nil {
+		t.Fatalf("read disabled pin rule: %v", err)
+	}
+	if ok {
+		t.Fatal("expected disabled pin rule not to match")
+	}
+
+	rootCmd = cmd.RootCmd(aerospaceClient)
+	_, err = testutils.CmdExecute(rootCmd, "pin", "--enable", ".*Brave.*")
+	if err != nil {
+		t.Fatalf("enable pin rule command failed: %v", err)
+	}
+	monitorID, ok, err := aerospace.PinnedMonitorIDForWindow(windows.Window{
+		AppName: "Brave Browser",
+	})
+	if err != nil {
+		t.Fatalf("read enabled pin rule: %v", err)
+	}
+	if !ok || monitorID != 2 {
+		t.Fatalf("expected enabled pin rule on monitor 2, got ok=%v monitor=%d", ok, monitorID)
+	}
+}
+
 func TestUnpinCmdRemovesFocusedWindowPin(t *testing.T) {
 	logger.SetDefaultLogger(&logger.EmptyLogger{})
 	stderr.SetBehavior(false)

--- a/cmd/pinned.go
+++ b/cmd/pinned.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"strconv"
+
+	windowsipc "github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/windows"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/aerospace"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/cli"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/logger"
+)
+
+func focusPinnedWindowOnOtherMonitor(
+	commandName string,
+	aerospaceClient *aerospace.AeroSpaceClient,
+	formatter *cli.OutputFormatter,
+	window windowsipc.Window,
+	currentMonitorID int,
+) (bool, error) {
+	pinnedMonitorID, pinned, err := aerospace.PinnedMonitorIDForWindow(window)
+	if err != nil || !pinned || pinnedMonitorID == currentMonitorID {
+		return false, err
+	}
+
+	focusErr := aerospaceClient.SetFocusByWindowID(window.WindowID)
+	if focusErr != nil {
+		return true, focusErr
+	}
+
+	if printErr := formatter.Print(cli.OutputEvent{
+		Command:   commandName,
+		Action:    actionFocus,
+		WindowID:  window.WindowID,
+		AppName:   window.AppName,
+		Workspace: window.Workspace,
+		Result:    "ok",
+		Message:   "pinned to monitor " + strconv.Itoa(pinnedMonitorID),
+	}); printErr != nil {
+		logger.GetDefaultLogger().LogError("PINNED: unable to write output", "error", printErr)
+	}
+	return true, nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,14 @@ https://i3wm.org/docs/userguide.html#_scratchpad
 		enableFilterFlag,
 		enableMonitorFlag,
 	}, ListCmd(customClient)))
+	rootCmd.AddCommand(compose([]flagsFn{
+		enableOutputFlag,
+		enableFilterFlag,
+	}, PinCmd(customClient)))
+	rootCmd.AddCommand(compose([]flagsFn{
+		enableOutputFlag,
+		enableFilterFlag,
+	}, UnpinCmd(customClient)))
 	rootCmd.AddCommand(InfoCmd(aerospaceClient))
 	rootCmd.AddCommand(HookCmd(aerospaceClient))
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -157,6 +157,21 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 			)
 
 			for _, window := range windowsOutsideView {
+				handled, pinErr := focusPinnedWindowOnOtherMonitor(
+					commandShow,
+					aerospaceClient,
+					formatter,
+					window,
+					currentMonitorID,
+				)
+				if pinErr != nil {
+					stderr.Printf("Error: unable to focus pinned window '%+v'\n%s", window, pinErr)
+					return
+				}
+				if handled {
+					continue
+				}
+
 				moveErr := mover.MoveWindowToWorkspace(
 					&window,
 					focusedWorkspace,
@@ -205,7 +220,7 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 					)
 					if printErr := formatter.Print(cli.OutputEvent{
 						Command:   commandShow,
-						Action:    "focus",
+						Action:    actionFocus,
 						WindowID:  window.WindowID,
 						AppName:   window.AppName,
 						Workspace: window.Workspace,
@@ -276,7 +291,7 @@ Similar to I3/Sway WM, it will toggle show/hide the window if called multiple ti
 				}
 				if printErr := formatter.Print(cli.OutputEvent{
 					Command:   commandShow,
-					Action:    "focus",
+					Action:    actionFocus,
 					WindowID:  window.WindowID,
 					AppName:   window.AppName,
 					Workspace: window.Workspace,

--- a/cmd/summon.go
+++ b/cmd/summon.go
@@ -75,6 +75,14 @@ Use "next" to cycle through scratchpad windows without specifying a pattern.
 				return
 			}
 
+			currentMonitorID := 0
+			monitor, monitorErr := aerospace.GetFocusedMonitor(
+				aerospaceClient.GetUnderlyingClient(),
+			)
+			if monitorErr == nil {
+				currentMonitorID = monitor.MonitorID
+			}
+
 			// Filter windows using the shared querier
 			querier := aerospace.NewAerospaceQuerier(aerospaceClient.GetUnderlyingClient())
 			mover := aerospace.NewAeroSpaceMover(aerospaceClient)
@@ -94,6 +102,21 @@ Use "next" to cycle through scratchpad windows without specifying a pattern.
 			}
 
 			for _, window := range windows {
+				handled, pinnedErr := focusPinnedWindowOnOtherMonitor(
+					commandSummon,
+					aerospaceClient,
+					formatter,
+					window,
+					currentMonitorID,
+				)
+				if pinnedErr != nil {
+					stderr.Println("Error: %v", pinnedErr)
+					return
+				}
+				if handled {
+					continue
+				}
+
 				setFocus := true
 				moveErr := mover.MoveWindowToWorkspace(
 					&window,

--- a/internal/aerospace/pins.go
+++ b/internal/aerospace/pins.go
@@ -32,7 +32,12 @@ func pinsStatePath() string {
 	if path := os.Getenv(pinsPathEnv); path != "" {
 		return path
 	}
-	return filepath.Join(os.TempDir(), "aerospace-scratchpad-pins.json")
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "aerospace-scratchpad-pins.json")
+	}
+	return filepath.Join(homeDir, ".config", "aerospace-scratchpad", "pinned.json")
 }
 
 func LoadPins() (PinsState, error) {

--- a/internal/aerospace/pins.go
+++ b/internal/aerospace/pins.go
@@ -1,0 +1,210 @@
+package aerospace
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/windows"
+)
+
+const pinsPathEnv = "AEROSPACE_SCRATCHPAD_PINS_PATH"
+
+type Pin struct {
+	MonitorID int `json:"monitor_id"`
+}
+
+type PinRule struct {
+	Pattern   string   `json:"pattern"`
+	Filters   []string `json:"filters,omitempty"`
+	MonitorID int      `json:"monitor_id"`
+}
+
+type PinsState struct {
+	Pinned map[int]Pin `json:"pinned"`
+	Rules  []PinRule   `json:"rules,omitempty"`
+}
+
+func pinsStatePath() string {
+	if path := os.Getenv(pinsPathEnv); path != "" {
+		return path
+	}
+	return filepath.Join(os.TempDir(), "aerospace-scratchpad-pins.json")
+}
+
+func LoadPins() (PinsState, error) {
+	path := pinsStatePath()
+	contents, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return PinsState{Pinned: map[int]Pin{}}, nil
+	}
+	if err != nil {
+		return PinsState{}, fmt.Errorf("unable to read pins state: %w", err)
+	}
+
+	var state PinsState
+	if unmarshalErr := json.Unmarshal(contents, &state); unmarshalErr != nil {
+		return PinsState{}, fmt.Errorf("unable to parse pins state: %w", unmarshalErr)
+	}
+	if state.Pinned == nil {
+		state.Pinned = map[int]Pin{}
+	}
+	return state, nil
+}
+
+func SavePins(state PinsState) error {
+	path := pinsStatePath()
+	if mkdirErr := os.MkdirAll(filepath.Dir(path), 0o750); mkdirErr != nil {
+		return fmt.Errorf("unable to create pins state directory: %w", mkdirErr)
+	}
+	if state.Pinned == nil {
+		state.Pinned = map[int]Pin{}
+	}
+	contents, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("unable to encode pins state: %w", err)
+	}
+	if writeErr := os.WriteFile(path, contents, 0o600); writeErr != nil {
+		return fmt.Errorf("unable to write pins state: %w", writeErr)
+	}
+	return nil
+}
+
+func PinWindow(windowID int, monitorID int) error {
+	state, err := LoadPins()
+	if err != nil {
+		return err
+	}
+	state.Pinned[windowID] = Pin{MonitorID: monitorID}
+	return SavePins(state)
+}
+
+func PinRuleForPattern(pattern string, filters []string, monitorID int) error {
+	state, err := LoadPins()
+	if err != nil {
+		return err
+	}
+	state.Rules = upsertPinRule(state.Rules, PinRule{
+		Pattern:   pattern,
+		Filters:   filters,
+		MonitorID: monitorID,
+	})
+	return SavePins(state)
+}
+
+func upsertPinRule(rules []PinRule, rule PinRule) []PinRule {
+	for index, existingRule := range rules {
+		if existingRule.Pattern == rule.Pattern && sameStrings(existingRule.Filters, rule.Filters) {
+			rules[index] = rule
+			return rules
+		}
+	}
+	return append(rules, rule)
+}
+
+func sameStrings(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func UnpinWindow(windowID int) error {
+	state, err := LoadPins()
+	if err != nil {
+		return err
+	}
+	delete(state.Pinned, windowID)
+	return SavePins(state)
+}
+
+func UnpinRuleForPattern(pattern string, filters []string) error {
+	state, err := LoadPins()
+	if err != nil {
+		return err
+	}
+
+	var remainingRules []PinRule
+	for _, rule := range state.Rules {
+		if rule.Pattern == pattern && sameStrings(rule.Filters, filters) {
+			continue
+		}
+		remainingRules = append(remainingRules, rule)
+	}
+	state.Rules = remainingRules
+	return SavePins(state)
+}
+
+func PinnedMonitorID(windowID int) (int, bool, error) {
+	state, err := LoadPins()
+	if err != nil {
+		return 0, false, err
+	}
+	pin, ok := state.Pinned[windowID]
+	return pin.MonitorID, ok, nil
+}
+
+func PinnedMonitorIDForWindow(window windows.Window) (int, bool, error) {
+	state, err := LoadPins()
+	if err != nil {
+		return 0, false, err
+	}
+	if pin, ok := state.Pinned[window.WindowID]; ok {
+		return pin.MonitorID, true, nil
+	}
+
+	for _, rule := range state.Rules {
+		matches, matchErr := pinRuleMatchesWindow(rule, window)
+		if matchErr != nil {
+			return 0, false, matchErr
+		}
+		if matches {
+			return rule.MonitorID, true, nil
+		}
+	}
+	return 0, false, nil
+}
+
+func pinRuleMatchesWindow(rule PinRule, window windows.Window) (bool, error) {
+	pattern, err := regexp.Compile(rule.Pattern)
+	if err != nil {
+		return false, fmt.Errorf("invalid pin pattern '%s': %w", rule.Pattern, err)
+	}
+	if !pattern.MatchString(window.AppName) {
+		return false, nil
+	}
+
+	filters, err := ParseFilters(rule.Filters)
+	if err != nil {
+		return false, err
+	}
+	return ApplyFilters(window, filters)
+}
+
+func ResolveWindowMonitorID(cli AeroSpaceWMClient, window windows.Window) (int, error) {
+	workspaces, err := ListWorkspacesWithMonitors(cli)
+	if err == nil {
+		for _, workspace := range workspaces {
+			if workspace.Workspace == window.Workspace {
+				return workspace.MonitorID, nil
+			}
+		}
+	}
+
+	monitor, monitorErr := GetFocusedMonitor(cli)
+	if monitorErr != nil {
+		if err != nil {
+			return 0, fmt.Errorf("unable to resolve window monitor: %w", err)
+		}
+		return 0, monitorErr
+	}
+	return monitor.MonitorID, nil
+}

--- a/internal/aerospace/pins.go
+++ b/internal/aerospace/pins.go
@@ -21,6 +21,7 @@ type PinRule struct {
 	Pattern   string   `json:"pattern"`
 	Filters   []string `json:"filters,omitempty"`
 	MonitorID int      `json:"monitor_id"`
+	Enabled   *bool    `json:"enabled,omitempty"`
 }
 
 type PinsState struct {
@@ -92,10 +93,12 @@ func PinRuleForPattern(pattern string, filters []string, monitorID int) error {
 	if err != nil {
 		return err
 	}
+	enabled := true
 	state.Rules = upsertPinRule(state.Rules, PinRule{
 		Pattern:   pattern,
 		Filters:   filters,
 		MonitorID: monitorID,
+		Enabled:   &enabled,
 	})
 	return SavePins(state)
 }
@@ -148,6 +151,20 @@ func UnpinRuleForPattern(pattern string, filters []string) error {
 	return SavePins(state)
 }
 
+func SetPinRuleEnabled(pattern string, filters []string, enabled bool) error {
+	state, err := LoadPins()
+	if err != nil {
+		return err
+	}
+
+	for index, rule := range state.Rules {
+		if rule.Pattern == pattern && sameStrings(rule.Filters, filters) {
+			state.Rules[index].Enabled = &enabled
+		}
+	}
+	return SavePins(state)
+}
+
 func PinnedMonitorID(windowID int) (int, bool, error) {
 	state, err := LoadPins()
 	if err != nil {
@@ -167,6 +184,9 @@ func PinnedMonitorIDForWindow(window windows.Window) (int, bool, error) {
 	}
 
 	for _, rule := range state.Rules {
+		if !pinRuleEnabled(rule) {
+			continue
+		}
 		matches, matchErr := pinRuleMatchesWindow(rule, window)
 		if matchErr != nil {
 			return 0, false, matchErr
@@ -176,6 +196,10 @@ func PinnedMonitorIDForWindow(window windows.Window) (int, bool, error) {
 		}
 	}
 	return 0, false, nil
+}
+
+func pinRuleEnabled(rule PinRule) bool {
+	return rule.Enabled == nil || *rule.Enabled
 }
 
 func pinRuleMatchesWindow(rule PinRule, window windows.Window) (bool, error) {

--- a/internal/aerospace/pins_test.go
+++ b/internal/aerospace/pins_test.go
@@ -82,3 +82,40 @@ func TestPinRulesMatchFutureWindowsByPattern(t *testing.T) {
 		t.Fatalf("expected pattern-pinned window on monitor 2, got ok=%v monitor=%d", ok, monitorID)
 	}
 }
+
+func TestDisabledPinRulesDoNotMatch(t *testing.T) {
+	t.Setenv("AEROSPACE_SCRATCHPAD_PINS_PATH", filepath.Join(t.TempDir(), "pins.json"))
+
+	if err := aerospace.PinRuleForPattern(".*Brave.*", nil, 2); err != nil {
+		t.Fatalf("pin rule: %v", err)
+	}
+	if err := aerospace.SetPinRuleEnabled(".*Brave.*", nil, false); err != nil {
+		t.Fatalf("disable rule: %v", err)
+	}
+
+	_, ok, err := aerospace.PinnedMonitorIDForWindow(windows.Window{
+		WindowID: 9876,
+		AppName:  "Brave Browser",
+	})
+	if err != nil {
+		t.Fatalf("match pin rule: %v", err)
+	}
+	if ok {
+		t.Fatal("expected disabled pin rule not to match")
+	}
+
+	enableErr := aerospace.SetPinRuleEnabled(".*Brave.*", nil, true)
+	if enableErr != nil {
+		t.Fatalf("enable rule: %v", enableErr)
+	}
+	monitorID, ok, err := aerospace.PinnedMonitorIDForWindow(windows.Window{
+		WindowID: 9877,
+		AppName:  "Brave Browser",
+	})
+	if err != nil {
+		t.Fatalf("match enabled pin rule: %v", err)
+	}
+	if !ok || monitorID != 2 {
+		t.Fatalf("expected enabled rule on monitor 2, got ok=%v monitor=%d", ok, monitorID)
+	}
+}

--- a/internal/aerospace/pins_test.go
+++ b/internal/aerospace/pins_test.go
@@ -1,12 +1,29 @@
 package aerospace_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/windows"
 	"github.com/cristianoliveira/aerospace-scratchpad/internal/aerospace"
 )
+
+func TestPinsUseDefaultConfigPath(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("AEROSPACE_SCRATCHPAD_PINS_PATH", "")
+
+	pinErr := aerospace.PinWindow(123, 2)
+	if pinErr != nil {
+		t.Fatalf("pin window: %v", pinErr)
+	}
+
+	path := filepath.Join(homeDir, ".config", "aerospace-scratchpad", "pinned.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected pins state at %s: %v", path, err)
+	}
+}
 
 func TestPinsState(t *testing.T) {
 	t.Setenv("AEROSPACE_SCRATCHPAD_PINS_PATH", filepath.Join(t.TempDir(), "pins.json"))

--- a/internal/aerospace/pins_test.go
+++ b/internal/aerospace/pins_test.go
@@ -1,0 +1,67 @@
+package aerospace_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cristianoliveira/aerospace-ipc/pkg/aerospace/windows"
+	"github.com/cristianoliveira/aerospace-scratchpad/internal/aerospace"
+)
+
+func TestPinsState(t *testing.T) {
+	t.Setenv("AEROSPACE_SCRATCHPAD_PINS_PATH", filepath.Join(t.TempDir(), "pins.json"))
+
+	_, ok, err := aerospace.PinnedMonitorID(123)
+	if err != nil {
+		t.Fatalf("expected missing pins file to load empty state: %v", err)
+	}
+	if ok {
+		t.Fatal("expected window to start unpinned")
+	}
+
+	pinErr := aerospace.PinWindow(123, 2)
+	if pinErr != nil {
+		t.Fatalf("pin window: %v", pinErr)
+	}
+
+	monitorID, ok, err := aerospace.PinnedMonitorID(123)
+	if err != nil {
+		t.Fatalf("read pin: %v", err)
+	}
+	if !ok || monitorID != 2 {
+		t.Fatalf("expected window pinned to monitor 2, got ok=%v monitor=%d", ok, monitorID)
+	}
+
+	unpinErr := aerospace.UnpinWindow(123)
+	if unpinErr != nil {
+		t.Fatalf("unpin window: %v", unpinErr)
+	}
+
+	_, ok, err = aerospace.PinnedMonitorID(123)
+	if err != nil {
+		t.Fatalf("read after unpin: %v", err)
+	}
+	if ok {
+		t.Fatal("expected window to be unpinned")
+	}
+}
+
+func TestPinRulesMatchFutureWindowsByPattern(t *testing.T) {
+	t.Setenv("AEROSPACE_SCRATCHPAD_PINS_PATH", filepath.Join(t.TempDir(), "pins.json"))
+
+	pinErr := aerospace.PinRuleForPattern(".*Brave.*", nil, 2)
+	if pinErr != nil {
+		t.Fatalf("pin rule: %v", pinErr)
+	}
+
+	monitorID, ok, err := aerospace.PinnedMonitorIDForWindow(windows.Window{
+		WindowID: 9876,
+		AppName:  "Brave Browser",
+	})
+	if err != nil {
+		t.Fatalf("match pin rule: %v", err)
+	}
+	if !ok || monitorID != 2 {
+		t.Fatalf("expected pattern-pinned window on monitor 2, got ok=%v monitor=%d", ok, monitorID)
+	}
+}


### PR DESCRIPTION
## Summary

Adds pinned scratchpads so a scratchpad window can stay bound to its monitor.

- Add `pin [pattern]` and `unpin [pattern]` commands
- No pattern pins/unpins the focused window by window ID
- Pattern uses existing app-name regex semantics and supports `--filter`
- Pattern pins are saved as rules, so future matching windows are pinned too
- Add `pin --disable [pattern]` and `pin --enable [pattern]` to toggle saved rules without deleting them
- `show`, `summon`, and `next` focus pinned windows on another monitor instead of moving them to the current workspace
- Keep `show` toggle-hide behavior for pinned windows already on the current monitor
- Store pin state at `~/.config/aerospace-scratchpad/pinned.json`
- Keep `AEROSPACE_SCRATCHPAD_PINS_PATH` override for tests/custom setups
- Document usage in README

## Verification

- `make lint`
- `make test`

## Notes

Pin state is intentionally lightweight:

- focused-window pins are window-ID based
- pattern pins are durable rules based on app-name regex + filters
- rules without `enabled` remain enabled for backward compatibility
