### PR TITLE
chore(deps): bump aerospace-ipc to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cristianoliveira/aerospace-scratchpad
 go 1.26.0
 
 require (
-	github.com/cristianoliveira/aerospace-ipc v0.3.1-0.20251202063927-7295ab8b40b9
+	github.com/cristianoliveira/aerospace-ipc v0.4.0
 	github.com/gkampitakis/go-snaps v0.5.11
 	github.com/goccy/go-yaml v1.15.13
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cristianoliveira/aerospace-ipc v0.3.1-0.20251202063927-7295ab8b40b9 h1:mJNb+3Ng7FgXjMJbAdsAfmgGEMyA7seOboXpluiohNM=
-github.com/cristianoliveira/aerospace-ipc v0.3.1-0.20251202063927-7295ab8b40b9/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
+github.com/cristianoliveira/aerospace-ipc v0.4.0 h1:TJlKRubVSzL8t0Lo0Y+lQu9c63ZbHnQ1TZ4XI4TeMXo=
+github.com/cristianoliveira/aerospace-ipc v0.4.0/go.mod h1:Dr928g0F980Y/Hu1t60RKOiWvQF02Lx5nLLM0SwPZ7M=
 github.com/gkampitakis/ciinfo v0.3.1 h1:lzjbemlGI4Q+XimPg64ss89x8Mf3xihJqy/0Mgagapo=
 github.com/gkampitakis/ciinfo v0.3.1/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=


### PR DESCRIPTION
Bumps [aerospace-ipc](https://github.com/cristianoliveira/aerospace-ipc) from the `v0.3.1-0.20251202063927-7295ab8b40b9` pseudo-version to the released **v0.4.0**.

**Release:** https://github.com/cristianoliveira/aerospace-ipc/releases/tag/v0.4.0

## What's in v0.4.0
v0.4.0 (tagged on `836e465`, `origin/main`) lands the socket-protocol overhaul that AeroSpace 0.21.x requires:
- Protocol version handshake + length-prefixed framing (protocol v1)
- Breaking interface refactor — service-based access (`focus`, `layout`, `windows`, `workspaces`)
- New `SetLayout` / `FocusBackAndForth` / workspaces move APIs (scratchpad already uses `SetLayout` for floating)

## Changes
- `go.mod`: require `github.com/cristianoliveira/aerospace-ipc v0.4.0`
- `go.sum`: updated hash

## Verification
Smoke-tested against a live AeroSpace **0.21.2-Beta** socket (status: Compatible):
- `go build` / `go test ./... -count=1` ✅
- `make lint` ✅ 0 issues
- `info`, `list`, `show -n`, `move -n`, `summon -n`, `next -n` all exercise the new ipc client cleanly

No code changes required — the scratchpad was already adapted to the post-refactor interface.
