### PR TITLE
docs: require AeroSpace 0.21.0+ for socket protocol v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ A I3/Sway like scratchpad extension for [AeroSpace WM](https://github.com/nikita
 
 ## AeroSpace Compatibility
 
- - AeroSpace v0.20.x use v0.4.x or higher
+ - AeroSpace v0.21.x use the latest version (socket protocol v1)
+ - AeroSpace v0.20.x use v0.5.x
  - AeroSpace v0.19.x use v0.3.x or lower
 
 **Work in Progress**
@@ -183,7 +184,7 @@ exec-and-forget aerospace-scratchpad show \
 
 ## Installation
 
-**Min AeroSpace version**: 0.20.x
+**Min AeroSpace version**: 0.21.0
 
 ### Using Homebrew
 


### PR DESCRIPTION
Documents the new minimum AeroSpace version requirement introduced by the socket-protocol-v1 client.

Companion to #150 (aerospace-ipc v0.4.0 bump).

## Why
aerospace-ipc v0.4.0 speaks **socket protocol v1**, which requires AeroSpace 0.21.0 or newer (per [aerospace-ipc `constants.go`](https://github.com/cristianoliveira/aerospace-ipc/blob/v0.4.0/internal/constants/constants.go)). The README previously advertised a 0.20.x floor, which is no longer accurate.

**ipc release:** https://github.com/cristianoliveira/aerospace-ipc/releases/tag/v0.4.0

## Changes (`README.md`)
- Compatibility table: added the 0.21.x row (latest, protocol v1); corrected 0.20.x to `v0.5.x`
- `Min AeroSpace version`: `0.20.x` → `0.21.0`

## Notes
- `v0.5.x` is the last scratchpad line that runs on 0.20.x — it depends on the pre-protocol-v1 ipc pseudo-version (commit `7295ab8`, before the protocol-v1 work).
- The runtime compatibility check in `cmd/info.go` already delegates to the ipc client's version constant, so `info` correctly reports "Compatible" against 0.21.x. No code change needed.
