### PR TITLE
chore(version): bump version to v0.6.0

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,4 +120,4 @@ func Execute(
 // and then run scripts/validate-version.sh.
 //
 //nolint:gochecknoglobals // version is overridden via build flags
-var VERSION = "v0.5.1"
+var VERSION = "v0.6.0"

--- a/nix/package-default.nix
+++ b/nix/package-default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
   pkgs.buildGoModule rec {
     name = "aerospace-scratchpad";
-    version = "v0.5.1";
+    version = "v0.6.0";
 
     src = pkgs.fetchFromGitHub {
       owner = "cristianoliveira";


### PR DESCRIPTION
Release prep: bump VERSION to v0.6.0 (cmd/root.go + nix/package-default.nix). Mirrors the v0.6.0-a dev-marker pattern (c39ea60). nix sha256 left for the post-release nix-release job.