### PR TITLE
docs: add scoped agent guidance

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,9 @@
+# .github
+
+GitHub Actions and issue templates.
+
+- Reuse Make targets so local and CI verification stay aligned.
+- Keep release, version bump, nightly reset, and push validation workflows separate.
+- Pin action versions deliberately and minimize workflow permissions.
+- Preserve required secrets and release inputs; never embed credentials.
+- Validate YAML and inspect trigger/path changes carefully because they alter when automation runs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# aerospace-scratchpad
+
+Go CLI providing i3/Sway-like scratchpads for AeroSpace WM through `aerospace-ipc`.
+
+## Architecture
+
+- `main.go`: composition root; create logger and IPC client, then call `cmd.Execute`.
+- `cmd/`: Cobra commands and use-case orchestration. See `cmd/AGENTS.md`.
+- `internal/aerospace/`: AeroSpace adapter and scratchpad query/move logic. See its guide.
+- `internal/cli/`: output formatting and CLI validation.
+- `internal/constants/`, `internal/logger/`, `internal/stderr/`: shared infrastructure.
+- `internal/mocks/`, `internal/testutils/`: generated mocks and test support.
+- `docs/`, `examples/`: user documentation and integrations.
+- `nix/`, `scripts/`, `.github/`: packaging and automation.
+
+Dependency direction is `main -> cmd -> internal packages`. Keep business decisions out of `main.go`. Production packages must not import test support.
+
+## Domain rules
+
+- Hidden windows live in `.scratchpad` or `.scratchpad.<monitor-id>`.
+- Scratchpad windows include windows on scratchpad workspaces and floating windows.
+- Preserve distinct semantics: `show` toggles, `summon` brings forward, `move` hides, `next` cycles.
+- Use the injected `AeroSpaceWMClient`; do not spawn `aerospace` processes when IPC supports the operation.
+
+## Workflow
+
+- Follow test-first development. Cover successful and error paths.
+- Match nearby table-driven and snapshot test style.
+- Run `make test`, `make lint`, and `make build` before finishing.
+- Update snapshots only for intentional output changes: `make update-snap-all`.
+- Use `make fmt` for Go formatting and lint fixes.
+- Generated files under `internal/mocks/` must be regenerated, not hand-edited.
+
+External AeroSpace references are available under `.tmp/docs/`; runtime logs are under `.tmp/aerospace-scratchpad.log`.

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -1,0 +1,24 @@
+# cmd
+
+Cobra presentation and application-orchestration layer.
+
+## Responsibilities
+
+- Define command arguments, flags, help, validation, and output events.
+- Coordinate `internal/aerospace` query and move operations.
+- Keep command semantics distinct: `move`, `show`, `summon`, `next`, `list`, `hook`, and `info`.
+- Wire shared flags in `root.go`; do not duplicate flag definitions across commands.
+
+## Boundaries
+
+- Put reusable AeroSpace querying or movement rules in `internal/aerospace`, not command files.
+- Put reusable serialization in `internal/cli`.
+- Commands receive interfaces/clients from `RootCmd`; do not construct IPC clients here.
+- Send scriptable results through the output formatter and errors through the established stderr behavior.
+
+## Tests
+
+- Add or change command tests first in matching `*_test.go` files.
+- Test success and failure behavior using `internal/testutils` and mocks.
+- Snapshot user-visible output. Update snapshots only when the contract intentionally changes.
+- Verify with `go test ./cmd -v`; for output changes also run `make update-snap-all` and inspect diffs.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,9 @@
+# docs
+
+User-facing documentation for installation, commands, filters, hooks, and multi-monitor behavior.
+
+- Treat CLI help and tested behavior as source of truth.
+- Keep examples executable and use current flag names/output formats.
+- Explain the distinction between `show`, `summon`, and `move`.
+- Document user-visible compatibility or output changes together with code changes.
+- Avoid implementation details that can drift; link to focused pages instead of duplicating content.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,8 @@
+# examples
+
+Small integrations demonstrating real CLI workflows.
+
+- Prefer short, runnable examples built on documented commands and machine-readable output.
+- Handle empty results and command failures explicitly.
+- Do not duplicate the CLI's filtering or scratchpad logic in scripts.
+- Keep examples portable unless the example clearly declares an external dependency.

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -1,0 +1,11 @@
+# internal
+
+Private implementation packages for the CLI.
+
+- `aerospace`: scratchpad domain adapter and IPC operations.
+- `cli`: formatting and validation independent of Cobra command wiring.
+- `constants`: shared stable names and environment keys.
+- `logger`, `stderr`: process infrastructure.
+- `mocks`, `testutils`: test-only support.
+
+Keep dependencies directed toward small support packages. Avoid imports from `cmd` into `internal`. Production code must not depend on `mocks` or `testutils`.

--- a/internal/aerospace/AGENTS.md
+++ b/internal/aerospace/AGENTS.md
@@ -1,0 +1,24 @@
+# internal/aerospace
+
+Owns the translation between scratchpad behavior and AeroSpace IPC.
+
+## Files
+
+- `client.go`: wraps upstream client, exposes common operations, connection lifetime, and dry-run behavior.
+- `querier.go`: finds/filter windows, resolves monitor/workspace names, and persists `next` cycling state.
+- `mover.go`: performs workspace, focus, and floating-layout transitions.
+
+## Rules
+
+- Depend on the injected `AeroSpaceWMClient`; keep IPC details behind this boundary.
+- Query code discovers state; mover code changes state.
+- Preserve `.scratchpad` for single-monitor behavior and `.scratchpad.<monitor-id>` for monitor-specific behavior.
+- Use raw `Connection().SendCommand` only when the upstream typed API does not expose the operation.
+- Dry-run must avoid mutations while preserving useful output.
+- Wrap errors with operation context; do not silently discard IPC failures.
+
+## Tests
+
+- Write focused tests before behavior changes, including no-window/error paths and multi-monitor cases.
+- Use deterministic mock monitor/window/workspace state.
+- Run `go test ./internal/aerospace -v` and then `make test`.

--- a/internal/cli/AGENTS.md
+++ b/internal/cli/AGENTS.md
@@ -1,0 +1,11 @@
+# internal/cli
+
+Reusable command-line output and validation helpers.
+
+- Keep formatting independent of Cobra and AeroSpace IPC.
+- Preserve output contracts for `text`, `json`, `tsv`, and `csv`.
+- Add fields once in the shared event/row model; do not implement format-specific duplicate business rules.
+- Quote separated values deterministically.
+- Validate unsupported formats and invalid arguments explicitly.
+
+Write tests first for every format and error path. Run `go test ./internal/cli -v`; intentional output changes may require command snapshot updates.

--- a/internal/constants/AGENTS.md
+++ b/internal/constants/AGENTS.md
@@ -1,0 +1,8 @@
+# internal/constants
+
+Single source of truth for stable configuration names.
+
+- Keep scratchpad workspace names, state/marker paths, socket keys, and logging environment keys here.
+- Use domain-facing names.
+- Do not add mutable state or behavior.
+- Import constants instead of repeating string literals across packages.

--- a/internal/logger/AGENTS.md
+++ b/internal/logger/AGENTS.md
@@ -1,0 +1,11 @@
+# internal/logger
+
+Process-wide structured logging infrastructure.
+
+- Configuration comes from the environment constants package.
+- Keep logger initialization and closing in the composition root.
+- Logging must not alter command stdout contracts.
+- Preserve the no-op logger for deterministic tests.
+- Never log as a substitute for returning an actionable error.
+
+Run package tests when changing configuration, levels, file handling, or JSON helpers, followed by `make test`.

--- a/internal/mocks/AGENTS.md
+++ b/internal/mocks/AGENTS.md
@@ -1,0 +1,8 @@
+# internal/mocks
+
+Generated GoMock implementations for AeroSpace IPC boundaries.
+
+- Do not hand-edit generated `*.go` files.
+- Change the source interface, then regenerate with `scripts/mock-generator.sh`.
+- Keep generated mocks test-only; production packages must not import this tree.
+- After regeneration, run `make test` and review the generated diff for unexpected interface changes.

--- a/internal/stderr/AGENTS.md
+++ b/internal/stderr/AGENTS.md
@@ -1,0 +1,10 @@
+# internal/stderr
+
+Central error presentation and exit behavior.
+
+- Keep stderr output consistent and separate from scriptable stdout.
+- Log errors before presenting them.
+- Preserve configurable exit behavior used by tests.
+- Do not introduce business decisions here.
+
+Any output wording change is user-visible: test failure and non-exiting test paths and inspect affected snapshots.

--- a/internal/testutils/AGENTS.md
+++ b/internal/testutils/AGENTS.md
@@ -1,0 +1,9 @@
+# internal/testutils
+
+Shared deterministic test harness for commands and internal packages.
+
+- Centralize reusable client state, IPC command simulation, CLI execution, logger setup, and snapshot helpers here.
+- Model AeroSpace behavior needed by tests; avoid copying production algorithms into mocks.
+- Keep fixtures explicit and deterministic: no real socket, window manager, clock, or user state.
+- Add helpers only when multiple tests benefit; keep scenario-specific setup near its test.
+- Snapshot names and output must remain stable unless behavior intentionally changes.

--- a/nix/AGENTS.md
+++ b/nix/AGENTS.md
@@ -1,0 +1,8 @@
+# nix
+
+Nix package definitions for default, source, and nightly builds.
+
+- Keep shared package logic centralized; variants should only override variant-specific source/version inputs.
+- Update hashes through `scripts/update-nix-hash.sh` where applicable.
+- Preserve flake outputs consumed by `make nix-build`, `make nix-build-source`, and `make nix-build-nightly`.
+- Validate the affected target; use `make nix-build-all` when shared packaging changes.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,9 @@
+# scripts
+
+Repository maintenance automation.
+
+- Scripts must be non-interactive when used by CI and fail on errors.
+- Keep version validation, mock generation, Nix hash updates, and benchmarks focused in separate scripts.
+- Resolve paths relative to repository root rather than caller working directory.
+- Do not hand-edit outputs when an existing generator owns them.
+- Test changed scripts with a timeout and run the related Make target.


### PR DESCRIPTION
## Summary

- add root architecture and workflow guidance for coding agents
- add scoped guidance for commands and internal packages
- document boundaries for generated mocks, tests, docs, packaging, scripts, and GitHub automation
